### PR TITLE
DM-5690 Fix exclude path for doc snippets

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -87,7 +87,7 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['README.rst', '_build', 'development/docs/snippets']
+exclude_patterns = ['README.rst', '_build', 'docs/snippets']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.


### PR DESCRIPTION
This is needed to prevent duplicate label warnings.

Fixes bug introduced in DM-4793.