### PR TITLE
DM-5826: Clarify division of Git setup and workflow docs

### DIFF
--- a/tools/git_setup.rst
+++ b/tools/git_setup.rst
@@ -1,12 +1,19 @@
-############################
-Git Setup and Best Practices
-############################
+################################
+Git Configuration Best Practices
+################################
 
-This page collects best practices for configuration and using Git for DM development.
+This page collects best practices for configuring Git for DM development.
 
 *See also*:
 
-- :doc:`/processes/workflow` for our :ref:`official Git user.email configuration requirement <git-setup>` as well as policies for `Git branch naming <git-branching>` and :ref:`merging <workflow-code-review-merge>`.
+- :doc:`/processes/workflow` for guidance on how we use Git, including:
+
+  - Our official :ref:`Git user.email configuration requirement <git-setup>`,
+  - :ref:`Git branch naming <git-branching>`,
+  - :ref:`Git branch merging <workflow-code-review-merge>`,
+  - :ref:`Git commit organization best practices <git-commit-organization-best-practices>`, and
+  - :ref:`Commit message best practices <git-commit-message-best-practices>`.
+
 - :doc:`/tools/git_lfs`
 
 .. _git-learning-resources:


### PR DESCRIPTION
This commit solves the issue where a reader might go to git_setup.rst to guidance on how to *use* Git for DM work rather than the official workflow document (workflow.rst). These need to be separate pages because the latter is a requirements document, and the former is intended to be simply helpful.

- Rename "Git Setup and Best Practices" to "Git Configuration Best Practices" to make scope clearer.
- Expand the See also section to make it easier for someone who landed on the Git Configuration Best Practices document to make their way into the appropriate part of the Workflow document.