### PR TITLE
DM-5973: Add python testing instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 _build
 .DS_Store
+__pycache__
+.cache

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -n
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/coding/python_testing.rst
+++ b/coding/python_testing.rst
@@ -4,25 +4,204 @@ Python Unit Testing
 
 This page provides technical guidance to developers writing unit tests for DM's Python code base.
 See :doc:`unit_test_policy` for an overview of LSST Stack testing.
+If you have legacy DM :mod:`unittest` ``suite``-based code (code that sets up a :class:`unittest.TestSuite` object by listing specific test classes and that uses :lfunc:`lsst.utils.tests.run` rather than :func:`unittest.main`) please refer to tech note `SQR-012`_ for porting instructions.
+LSST tests should be written using the :mod:`unittest` framework, with default test discovery, and should support being run using the `pytest`_ test runner.
 
-Memory Leak Testing
-===================
+.. _SQR-012: http://sqr-012.lsst.io
+.. _pytest: http://pytest.org
 
-:lmod:`lsst.utils.tests` provides several utilities for writing Python tests
-that developers should make use of. In particular,
-:lclass:`lsst.utils.tests.MemoryTestCase` is used to detect memory leaks in
-C++ objects. :lclass:`~lsst.utils.tests.MemoryTestCase` should be used in
-*all* tests, even if C++ code is not explicitly referenced.
+Introduction to ``unittest``
+============================
+
+This document will not attempt to explain full details of how to use :mod:`unittest` but instead shows common scenarios encountered in the LSST codebase.
+
+A simple :mod:`unittest` example is shown below:
+
+.. literalinclude:: unit_test_snippets/unittest_basic_example.py
+   :language: python
+
+The important things to note in this example are:
+
+* If the test is being executed using :command:`python` from the command line the :py:func:`unittest.main` call performs the test discovery and executes the tests, setting exit status to non-zero if any of the tests fail.
+* Test classes are executed in the order in which they appear in the test file.
+  In this case the tests in ``DemoTestCase1`` will be executed before those in ``DemoTestCase2``.
+* Test classes must, ultimately, inherit from :class:`unittest.TestCase` in order to be discovered and it is :ref:`recommended <py-utils-tests>` that :lclass:`lsst.utils.tests.TestCase` be used as the base class when :lmod:`~lsst.afw` objects are involved.
+  The tests themselves must be methods of the test class with names that begin with ``test``.
+  All other methods and classes will be ignored by the test system but can be used by tests.
+* If a test method completes the test passes, if it throws an uncaught exception the test has failed.
+
+Using a more advanced test runner
+=================================
+
+All tests should be written such that they are runnable using `pytest`_, a policy adopted in :jira:`RFC-69`.
+`pytest`_ provides a much richer execution and reporting environment for tests and can be used to run multiple tests files together.
+`pytest`_ test discovery is much more flexible than that provided by :mod:`unittest` but LSST test files should not take advantage of that flexibility as it can lead to inconsistency in test reports that depend on the specific test runner.
+In particular, care must be taken not to have free functions that use a ``test`` prefix or non-\ :class:`~unittest.TestCase` test classes that are named with a ``Test`` prefix in the test files.
+
+.. note::
+   The normal way to run tests is to use :command:`scons` or :command:`scons tests`.
+   :command:`scons` will then execute each of the tests and report any failures.
+   Currently tests are executed one at a time using :command:`python` and checking the command exit status.
+   Eventually :lmod:`~lsst.sconsUtils` will be modified to call :command:`py.test` directly with all Python test files (possibly with a different order each invocation).
+   It is therefore important that during this transition period developers check that tests run correctly with `pytest`_ by explicitly running :command:`py.test` when creating or updating test files.
+
+`pytest`_ can run tests from more than one file in a single invocation and this can be used to verify that there is no state contaminating later tests.
+To run `pytest`_ use the :command:`py.test` executable:
+
+.. code-block:: shell
+
+   $ py.test tests/*.py
+
+and to ensure that the order of test execution does not matter it is useful to sometimes run the tests in reverse order:
+
+.. code-block:: shell
+
+   $ py.test `ls -r tests/*.py`
+
+When writing tests it is important that tests are skipped using the proper :mod:`unittest` :ref:`skipping framework <python:unittest-skipping>` rather than returning from the test early.
+:mod:`unittest` supports skipping of individual tests and entire classes using decorators or skip exceptions.
+LSST code sometimes raises skip exceptions in :meth:`~unittest.TestCase.setUp` or :meth:`~unittest.TestCase.setUpClass` class methods and :mod:`unittest` provides much flexibility in how skipping can be implemented.
+It is also possible to indicate that a particular test is expected to fail, being reported as an error if the test unexpectedly passes.
+Expected failures can be used to write test code that triggers a reported bug before the fix to the bug has been implemented and without causing the continuous integration system to die.
+One of the primary advantages of using a modern test runner such as `pytest`_ is that it is very easy to generate machine-readable pass/fail/skip/xfail statistics to see how the system is evolving over time.
+
+Using a shared base class
+=========================
+
+For some tests it is helpful to provide a base class and then share it amongst multiple test classes that are configured with different attributes.
+If this is required be careful to not have helper functions prefixed with ``test`` and do not have the base class named with a ``Test`` prefix and ensure it does not inherit from :class:`~unittest.TestCase`, if you do `pytest`_ will attempt to find tests inside it.
+Historically LSST code has dealt with this by creating a test suite that only includes the classes to be tested, omitting the base class.
+This does not work in a `pytest`_ environment.
+
+Consider the following test code:
+
+.. literalinclude:: unit_test_snippets/unittest_baseclass.py
+   :language: python
+
+which inherits from the helper class and :class:`unittest.TestCase` and runs a single test without attempting to run any tests in ``BaseClass``.
+
+.. code-block:: shell
+
+   $ py.test -v coding/unit_test_snippets/unittest_baseclass.py
+   ======================================= test session starts ========================================
+   platform darwin -- Python 3.4.3, pytest-2.9.1, py-1.4.30, pluggy-0.3.1 -- /usr/local/bin/python3.4
+   cachedir: coding/unit_test_snippets/.cache
+   rootdir: coding/unit_test_snippets, inifile:
+   collected 1 items
+
+   coding/unit_test_snippets/unittest_baseclass.py::ThisIsTest1::testParam PASSED
+
+   ===================================== 1 passed in 0.02 seconds =====================================
+
+
+LSST Utility Test Support Classes
+=================================
+
+:lmod:`lsst.utils.tests` provides several utilities functions and classes for writing Python tests that developers should make use of.
+
+.. _py-utils-tests:
+
+Special Asserts
+---------------
+
+Inheriting from :lclass:`lsst.utils.tests.TestCase` rather than :class:`unittest.TestCase` enables two new asserts that are useful for doing element-wise comparison of two :mod:`numpy` arrays.
+
+:lmeth:`~lsst.utils.tests.TestCase.assertClose`
+   Asserts that the corresponding elements in two arrays are within the specified tolerance.
+:lmeth:`~lsst.utils.tests.TestCase.assertNotClose`
+   Asserts that the two arrays are different.
+
+Additionally, :lmod:`~lsst.afw` provides additional asserts that get loaded into :lclass:`lsst.utils.tests.TestCase` when the associated module is loaded.
+
+:lmeth:`~lsst.afw.coord.utils.assertCoordsNearlyEqual`
+   Assert that two coords represent nearly the same point on the sky (provided by :lmod:`lsst.afw.coord.utils`).
+:lmeth:`~lsst.afw.geom.utils.assertAnglesNearlyEqual`
+   Assert that two angles are nearly equal, ignoring wrap differences by default (provided by :lmod:`lsst.afw.geom.utils`).
+:lmeth:`~lsst.afw.geom.utils.assertPairsNearlyEqual`
+   Assert that two planar pairs (e.g. :lclass:`~lsst.afw.geom.Point2D` or :lclass:`~lsst.afw.geom.Extent2D`) are nearly equal (provided by :lmod:`lsst.afw.geom.utils`).
+:lmeth:`~lsst.afw.geom.utils.assertBoxesNearlyEqual`
+   Assert that two boxes (:lclass:`~lsst.afw.geom.Box2D` or :lclass:`~lsst.afw.geom.Box2I`) are nearly equal (provided by :lmod:`lsst.afw.geom.utils`).
+:lmeth:`~lsst.afw.image.basicUtils.assertWcsNearlyEqualOverBBox`
+   Compare :lmeth:`~lsst.afw.image.imageLib.Wcs.pixelToSky` and :lmeth:`~lsst.afw.image.imageLib.Wcs.skyToPixel` for two WCS over a rectangular grid of pixel positions (provided by :lmod:`lsst.afw.image.basicUtils`).
+:lmeth:`~lsst.afw.image.testUtils.assertImagesNearlyEqual`
+   Assert that two images are nearly equal, including non-finite values (provided by :lmod:`lsst.afw.image.testUtils`).
+:lmeth:`~lsst.afw.image.testUtils.assertMasksEqual`
+   Assert that two masks are equal (provided by :lmod:`lsst.afw.image.testUtils`).
+:lmeth:`~lsst.afw.image.testUtils.assertMaskedImagesNearlyEqual`
+   Assert that two masked images are nearly equal, including non-finite values (provided by :lmod:`lsst.afw.image.testUtils`).
+
+Testing Executables
+-------------------
+
+In some cases the test to be executed is a shell script or a compiled binary executable.
+In order for the test running environment to be aware of these tests a Python test file must be present that can be run by `pytest`_ to executes these tests in the :mod:`unittest` environment.
+If none of the tests require special arguments and all the files with the executable bit set are to be run, this can be achieved by copying the file :file:`$UTILS_DIR/tests/testExecutables.py` to the relevant :file:`tests` directory.
+The file is reproduced here:
+
+.. literalinclude:: unit_test_snippets/testExecutables.py
+   :linenos:
+   :language: python
+   :emphasize-lines: 8-9
+
+The ``EXECUTABLES`` variable can be a tuple containing the names of the executables to be run (relative to the directory containing the test file).
+``None`` indicates that the test script should discover the executables in the same directory as that containing the test file.
+The call to :lmeth:`~lsst.utils.tests.ExecutablesTestCase.create_executable_tests` initiates executable discovery and creates a test for each executable that is found.
+
+In some cases an explicit test has to be written either because some precondition has to be met before the test will stand a chance of running or because some arguments have to be passed to the executable.
+To support this the :lmeth:`~lsst.utils.tests.ExecutableTestCase.assertExecutable` method is available:
+
+.. code-block:: python
+
+   def testBinary(self):
+       self.assertExecutable("binary1", args=None,
+                             root_dir=os.path.dirname(__file__))
+
+Where ``binary1`` is the name of the executable relative to the root directory specified in the ``root_dir`` optional argument.
+Arguments can be provided to the ``args`` keyword parameter in the form of a sequence of arguments in a list or tuple.
+
+.. note::
+   The LSST codebase is currently in transition such that :lmod:`~lsst.sconsUtils` will run executables
+   itself as well as running Python test scripts that run executables.
+   Do not worry about this duplication of test running.
+   When the codebase has migrated to consistently use the testing scheme described in this section :lmod:`~lsst.sconsUtils` will be modified to disable the duplicate testing.
+
+
+Memory and file descriptor leak testing
+---------------------------------------
+
+:lclass:`lsst.utils.tests.MemoryTestCase` is used to detect memory leaks in C++ objects and leaks in file descriptors.
+:lclass:`~lsst.utils.tests.MemoryTestCase` should be used in *all* test files where :lmod:`~lsst.utils` is in the dependency chain, even if C++ code is not explicitly referenced.
 
 This example shows the basic structure of an LSST Python unit test module,
 including :lclass:`~lsst.utils.tests.MemoryTestCase`:
 
 .. literalinclude:: unit_test_snippets/unittest_runner_example.py
+   :linenos:
    :language: python
-   :emphasize-lines: 16
+   :emphasize-lines: 6, 16, 21
+
+
+which ends up running the single specified test plus the two running as part of the leak test:
+
+.. code-block:: shell
+
+   $ py.test -v unittest_runner_example.py
+   ============================= test session starts ==============================
+   platform darwin -- Python 2.7.11, pytest-2.8.5, py-1.4.31, pluggy-0.3.1 -- ~/lsstsw/miniconda/bin/python
+   cachedir: .cache
+   rootdir: .../coding/unit_test_snippets, inifile:
+   collected 3 items
+
+   unittest_runner_example.py::DemoTestCase::testDemo PASSED
+   unittest_runner_example.py::MemoryTester::testFileDescriptorLeaks <- .../lsstsw/stack/DarwinX86/utils/12.0.rc1+f79d1f7db4/python/lsst/utils/tests.py PASSED
+   unittest_runner_example.py::MemoryTester::testLeaks <- .../lsstsw/stack/DarwinX86/utils/12.0.rc1+f79d1f7db4/python/lsst/utils/tests.py PASSED
+
+   =========================== 3 passed in 0.28 seconds ===========================
 
 Note that :lclass:`~lsst.utils.tests.MemoryTestCase` must always be the
 final test suite.
+For the memory test to function properly the :lfunc:`lsst.utils.tests.init()` function must be invoked before any of the tests in the class are executed.
+Since LSST test scripts are required to run properly from the command-line and when called from within `pytest`_, the :lfunc:`~lsst.utils.tests.init()` function has to be in the file twice: once in the :ref:`setup_module <pytest:xunitsetup>` function that is called by `pytest`_ whenever a test module is loaded (`pytest`_ will not use the ``__main__`` code path), and also just before the call to :func:`unittest.main()` call to handle being called with :command:`python`.
 
 Unicode
 =======

--- a/coding/python_testing.rst
+++ b/coding/python_testing.rst
@@ -4,7 +4,7 @@ Python Unit Testing
 
 This page provides technical guidance to developers writing unit tests for DM's Python code base.
 See :doc:`unit_test_policy` for an overview of LSST Stack testing.
-If you have legacy DM :mod:`unittest` ``suite``-based code (code that sets up a :class:`unittest.TestSuite` object by listing specific test classes and that uses :lfunc:`lsst.utils.tests.run` rather than :func:`unittest.main`) please refer to tech note `SQR-012`_ for porting instructions.
+If you have legacy DM :mod:`unittest` ``suite``-based code (code that sets up a :class:`unittest.TestSuite` object by listing specific test classes and that uses :lfunc:`lsst.utils.tests.run` rather than :func:`unittest.main`), please refer to tech note `SQR-012`_ for porting instructions.
 LSST tests should be written using the :mod:`unittest` framework, with default test discovery, and should support being run using the `pytest`_ test runner.
 
 .. _SQR-012: http://sqr-012.lsst.io
@@ -25,10 +25,10 @@ The important things to note in this example are:
 * If the test is being executed using :command:`python` from the command line the :py:func:`unittest.main` call performs the test discovery and executes the tests, setting exit status to non-zero if any of the tests fail.
 * Test classes are executed in the order in which they appear in the test file.
   In this case the tests in ``DemoTestCase1`` will be executed before those in ``DemoTestCase2``.
-* Test classes must, ultimately, inherit from :class:`unittest.TestCase` in order to be discovered and it is :ref:`recommended <py-utils-tests>` that :lclass:`lsst.utils.tests.TestCase` be used as the base class when :lmod:`~lsst.afw` objects are involved.
+* Test classes must, ultimately, inherit from :class:`unittest.TestCase` in order to be discovered, and it is :ref:`recommended <py-utils-tests>` that :lclass:`lsst.utils.tests.TestCase` be used as the base class when :lmod:`~lsst.afw` objects are involved.
   The tests themselves must be methods of the test class with names that begin with ``test``.
   All other methods and classes will be ignored by the test system but can be used by tests.
-* If a test method completes the test passes, if it throws an uncaught exception the test has failed.
+* If a test method completes, the test passes; if it throws an uncaught exception the test has failed.
 
 Using a more advanced test runner
 =================================
@@ -39,7 +39,7 @@ Using a more advanced test runner
 
 All tests should be written such that they are runnable using `pytest`_, a policy adopted in :jira:`RFC-69`.
 `pytest`_ provides a much richer execution and reporting environment for tests and can be used to run multiple tests files together.
-`pytest`_ test discovery is much more flexible than that provided by :mod:`unittest` but LSST test files should not take advantage of that flexibility as it can lead to inconsistency in test reports that depend on the specific test runner.
+`pytest`_ test discovery is much more flexible than that provided by :mod:`unittest`, but LSST test files should not take advantage of that flexibility as it can lead to inconsistency in test reports that depend on the specific test runner.
 In particular, care must be taken not to have free functions that use a ``test`` prefix or non-\ :class:`~unittest.TestCase` test classes that are named with a ``Test`` prefix in the test files.
 
 .. note::
@@ -64,7 +64,7 @@ and to ensure that the order of test execution does not matter it is useful to s
 
 When writing tests it is important that tests are skipped using the proper :mod:`unittest` :ref:`skipping framework <python:unittest-skipping>` rather than returning from the test early.
 :mod:`unittest` supports skipping of individual tests and entire classes using decorators or skip exceptions.
-LSST code sometimes raises skip exceptions in :meth:`~unittest.TestCase.setUp` or :meth:`~unittest.TestCase.setUpClass` class methods and :mod:`unittest` provides much flexibility in how skipping can be implemented.
+LSST code sometimes raises skip exceptions in :meth:`~unittest.TestCase.setUp` or :meth:`~unittest.TestCase.setUpClass` class methods.
 It is also possible to indicate that a particular test is expected to fail, being reported as an error if the test unexpectedly passes.
 Expected failures can be used to write test code that triggers a reported bug before the fix to the bug has been implemented and without causing the continuous integration system to die.
 One of the primary advantages of using a modern test runner such as `pytest`_ is that it is very easy to generate machine-readable pass/fail/skip/xfail statistics to see how the system is evolving over time.
@@ -73,7 +73,8 @@ Using a shared base class
 =========================
 
 For some tests it is helpful to provide a base class and then share it amongst multiple test classes that are configured with different attributes.
-If this is required be careful to not have helper functions prefixed with ``test`` and do not have the base class named with a ``Test`` prefix and ensure it does not inherit from :class:`~unittest.TestCase`, if you do `pytest`_ will attempt to find tests inside it.
+If this is required, be careful to not have helper functions prefixed with ``test``.
+Do not have the base class named with a ``Test`` prefix and ensure it does not inherit from :class:`~unittest.TestCase`; if you do, `pytest`_ will attempt to find tests inside it and will issue a warning if none can be found.
 Historically LSST code has dealt with this by creating a test suite that only includes the classes to be tested, omitting the base class.
 This does not work in a `pytest`_ environment.
 
@@ -101,7 +102,7 @@ which inherits from the helper class and :class:`unittest.TestCase` and runs a s
 LSST Utility Test Support Classes
 =================================
 
-:lmod:`lsst.utils.tests` provides several utilities functions and classes for writing Python tests that developers should make use of.
+:lmod:`lsst.utils.tests` provides several helpful functions and classes for writing Python tests that developers should make use of.
 
 .. _py-utils-tests:
 
@@ -138,7 +139,7 @@ Testing Executables
 -------------------
 
 In some cases the test to be executed is a shell script or a compiled binary executable.
-In order for the test running environment to be aware of these tests a Python test file must be present that can be run by `pytest`_ to executes these tests in the :mod:`unittest` environment.
+In order for the test running environment to be aware of these tests, a Python test file must be present that can be run by `pytest`_.
 If none of the tests require special arguments and all the files with the executable bit set are to be run, this can be achieved by copying the file :file:`$UTILS_DIR/tests/testExecutables.py` to the relevant :file:`tests` directory.
 The file is reproduced here:
 
@@ -160,7 +161,7 @@ To support this the :lmeth:`~lsst.utils.tests.ExecutableTestCase.assertExecutabl
        self.assertExecutable("binary1", args=None,
                              root_dir=os.path.dirname(__file__))
 
-Where ``binary1`` is the name of the executable relative to the root directory specified in the ``root_dir`` optional argument.
+where ``binary1`` is the name of the executable relative to the root directory specified in the ``root_dir`` optional argument.
 Arguments can be provided to the ``args`` keyword parameter in the form of a sequence of arguments in a list or tuple.
 
 .. note::

--- a/coding/python_testing.rst
+++ b/coding/python_testing.rst
@@ -33,6 +33,10 @@ The important things to note in this example are:
 Using a more advanced test runner
 =================================
 
+.. note::
+   `pytest`_ is not currently installed as part of a LSST stack installation.
+   It can be installed using :command:`conda install pytest` or :command:`pip install pytest`.
+
 All tests should be written such that they are runnable using `pytest`_, a policy adopted in :jira:`RFC-69`.
 `pytest`_ provides a much richer execution and reporting environment for tests and can be used to run multiple tests files together.
 `pytest`_ test discovery is much more flexible than that provided by :mod:`unittest` but LSST test files should not take advantage of that flexibility as it can lead to inconsistency in test reports that depend on the specific test runner.

--- a/coding/python_testing.rst
+++ b/coding/python_testing.rst
@@ -5,6 +5,25 @@ Python Unit Testing
 This page provides technical guidance to developers writing unit tests for DM's Python code base.
 See :doc:`unit_test_policy` for an overview of LSST Stack testing.
 
+Memory Leak Testing
+===================
+
+:lmod:`lsst.utils.tests` provides several utilities for writing Python tests
+that developers should make use of. In particular,
+:lclass:`lsst.utils.tests.MemoryTestCase` is used to detect memory leaks in
+C++ objects. :lclass:`~lsst.utils.tests.MemoryTestCase` should be used in
+*all* tests, even if C++ code is not explicitly referenced.
+
+This example shows the basic structure of an LSST Python unit test module,
+including :lclass:`~lsst.utils.tests.MemoryTestCase`:
+
+.. literalinclude:: unit_test_snippets/unittest_runner_example.py
+   :language: python
+   :emphasize-lines: 16
+
+Note that :lclass:`~lsst.utils.tests.MemoryTestCase` must always be the
+final test suite.
+
 Unicode
 =======
 

--- a/coding/unit_test_policy.rst
+++ b/coding/unit_test_policy.rst
@@ -85,26 +85,11 @@ C++: boost.test
     function testing <unit_test_private_functions>`.
 
 Python: unittest
-    LSST DM developers should use `Python's unittest framework`_.
-
-    :lmod:`lsst.utils.tests` provides several utilities for writing Python tests
-    that developers should make use of. In particular,
-    :lclass:`lsst.utils.tests.MemoryTestCase` is used to detect memory leaks in C++
-    objects. :lclass:`~lsst.utils.tests.MemoryTestCase` should be used in *all* tests, even if C++ code
-    is not explicitly referenced.
-
-    This example shows the basic structure of an LSST Python unit test module,
-    including :lclass:`~lsst.utils.tests.MemoryTestCase`:
-
-    .. literalinclude:: unit_test_snippets/unittest_runner_example.py
-       :language: python
-       :emphasize-lines: 21
-
-    Note that ``MemoryTestCase`` must always be the final test suite.
+    LSST DM developers should use the Python :mod:`unittest` framework.
+    Details on particular conventions to use for LSST DM code are :doc:`described later <python_testing>`.
 
 .. _single-header variant: http://www.boost.org/doc/libs/1_60_0/libs/test/doc/html/boost_test/usage_variants.html#boost_test.usage_variants.single_header
 .. _Boost Unit Test Framework: http://www.boost.org/doc/libs/1_60_0/libs/test/doc/html/index.html
-.. _Python's unittest framework: https://docs.python.org/library/unittest.html
 
 Unit Testing Composite Objects
 ==============================

--- a/coding/unit_test_snippets/testExecutables.py
+++ b/coding/unit_test_snippets/testExecutables.py
@@ -1,0 +1,12 @@
+import unittest
+import lsst.utils.tests
+
+
+class UtilsBinaryTester(lsst.utils.tests.ExecutablesTestCase):
+    pass
+
+EXECUTABLES = None
+UtilsBinaryTester.create_executable_tests(__file__, EXECUTABLES)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/coding/unit_test_snippets/unittest_baseclass.py
+++ b/coding/unit_test_snippets/unittest_baseclass.py
@@ -1,0 +1,13 @@
+import unittest
+
+
+class BaseClass():
+    def testParam(self):
+        self.assertLess(self.PARAM, 5)
+
+
+class ThisIsTest1(BaseClass, unittest.TestCase):
+    PARAM = 3
+
+if __name__ == "__main__":
+    unittest.main()

--- a/coding/unit_test_snippets/unittest_baseclass.py
+++ b/coding/unit_test_snippets/unittest_baseclass.py
@@ -1,7 +1,7 @@
 import unittest
 
 
-class BaseClass():
+class BaseClass(object):
     def testParam(self):
         self.assertLess(self.PARAM, 5)
 

--- a/coding/unit_test_snippets/unittest_basic_example.py
+++ b/coding/unit_test_snippets/unittest_basic_example.py
@@ -1,0 +1,22 @@
+import unittest
+import math
+
+
+class DemoTestCase1(unittest.TestCase):
+    """Demo test case 1."""
+
+    def testDemo(self):
+        self.assertGreater(10, 5)
+
+
+class DemoTestCase2(unittest.TestCase):
+    """Demo test case 2."""
+
+    def testDemo1(self):
+        self.assertNotEqual("string1", "string2")
+
+    def testDemo2(self):
+        self.assertAlmostEqual(3.14, math.pi, places=2)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/coding/unit_test_snippets/unittest_runner_example.py
+++ b/coding/unit_test_snippets/unittest_runner_example.py
@@ -1,31 +1,22 @@
 import unittest
+import lsst.utils.tests
 
-import lsst.utils.tests as utilsTests
+
+def setup_module(module):
+    lsst.utils.tests.init()
 
 
-class DemoTestCase(utilsTests.TestCase):
+class DemoTestCase(lsst.utils.tests.TestCase):
     """Demo test case."""
 
     def testDemo(self):
-        assert True
+        self.assertNotIn("i", "team")
 
 
-def suite():
-    """Returns a suite containing all the test cases in this module."""
-    utilsTests.init()
-
-    suites = []
-    # Test suites for this module here
-    suites += unittest.makeSuite(DemoTestCase)
-    # MemoryTestCase to find C++ memory leaks
-    suites += unittest.makeSuite(utilsTests.MemoryTestCase)
-    return unittest.TestSuite(suites)
-
-
-def run(exit=False):
-    """Run the tests"""
-    utilsTests.run(suite(), exit)
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
 
 
 if __name__ == "__main__":
-    run(True)
+    lsst.utils.tests.init()
+    unittest.main()

--- a/conf.py
+++ b/conf.py
@@ -379,5 +379,7 @@ epub_exclude_files = ['search.html']
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/2.7', None),
-    'astropy': ('http://docs.astropy.org/en/stable/', None)
+    'astropy': ('http://docs.astropy.org/en/stable/', None),
+    'numpy': ('http://docs.scipy.org/doc/numpy/', None),
+    'pytest': ('http://pytest.org/latest', None),
 }


### PR DESCRIPTION
Modifications to the developer guide to add instructions on how LSST DM code should do python testing.