### PR TITLE
Publish with LSST the Docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: false
+language: python
+matrix:
+  include:
+    - python: "3.5"
+      env: LTD_MASON_BUILD=true
+install:
+  - pip install -r requirements.txt
+  - pip install "ltd-mason>=0.2,<0.3"
+script:
+  - sphinx-build -b html -a -n -W -d _build/doctree . _build/html
+after_success:
+  - ltd-mason-travis --html-dir _build/html
+env:
+  global:
+    - LTD_MASON_BUILD=false  # disable builds in regular text matrix
+    - LTD_MASON_PRODUCT="developer"
+    # travis encrypt "LTD_MASON_AWS_ID=... LTD_MASON_AWS_SECRET=..." --add env.global 
+    - secure: "iJmYxuGoIciqS1KkkajdxJf0bmPN61hnbs8bwepk1lcv7HIBRF09MvmmeXFn8JLK3CYP0CPJSQRwU5kQlU8xfsaEm3ccx4Ckqtdz/iyUOajKd5xGiZ6HTEbw2rTLDxyPFtZzaE3QG7EnTPAQEHUSuWStfmc8GEqjlOiRfjUbmvwbiP8uCaaYM3xWPn2RaAn6xiYVLpZdvDM3rWz/UhEcjFN9vDoSAcqz67EJNgtbQ2Ogu9Wo4e6t2/RZuy67+iQOjKZ4pRKlDY7LJfYO8TWdBXRIDmJKwgzrbLqXGSaIdbz98LaMO0lnSerHnXTHVD7FOsfLa7hHOKFS/GXtyF01Ckg//GbBHzZoLvUcBxAFej1Yk2MKmoDca+Sm2/w9G+cULmFztHt2FIKWiySmAsnQUNM4se0qG1RkjcSvM04DqMJ50LUyUWkNZpskjIMojCj0/b7rWgLgPY74ttZKh6A+zVGuKb9QOp7Wv043RKYkqq4VwYJFv+O/Sp0kDxn/1o/yC2a8YxoywFS7JP7A3q3K+ao+AqcH25qw2vmDi6+ZedpDvxXeZlnMRFht5h16bcuhvpZPRwooK22WJIa6KGPhoPWsu0ack1R4xNliDwNwy9vIndRdKgTmPVrzhaEUfNkVPZyKXLHtAnp5K0IIenGUm6HV+rUdmhSHNCXdGrXlmI8="
+    # travis encrypt "LTD_KEEPER_URL=... LTD_KEEPER_USER=... LTD_KEEPER_PASSWORD=..." --add env.global 
+    - secure: "Wl4KK9D9yO3HuO7I9IChjBvfYostBMB9rq46hEIvdYeGshFG4o0qW5WIfDkorKd83IN/mieEhhDIQGs3D5z8BRbsAYhjH0FOZDebACayM0UrBbS+caH4+2Zpvvb7xAG+UTd3Np+R3xVbWyk3TqXupjNj4YWZx0isIPaG4RN3j4FQVifLU3wKXN+lhKQE0wkn4k6j2Y8kyqSKJS29c7zANU+AskOVf7GXnIkU9H03oWB+UIdapUEviFbksOigp0tmpjVrNgN9cJCXjMOXMaIs3abmiLU9X8RcarKCpv06CyvsfmtP+jQ/gb5thWyRRBAAKx9RmTUpqkej9QENQBfZMmR4WuEFpmC/OzkjkaTsB+Sfebfai0IaZPXuf8X7QNFWml1LVS4TMskGImPz6797bi2NS+2G+XtZAxJVNLZ4QD0Nmp8gO36K1U2LIjSbpI8ieN2fuJF0Dfd5Cu5g9FGUI6nQU3hUgfuyezuTJw1fi0HuBIj8wK2nlbNg1931vbYfnlSylFAVJ8sViWGUUoXPDB6VdBEtWqqL8tnUxjJjdB50PZDepkA+csVZc9UV6Qrt8AN//Mp0tpO0QlmvgqRjQ0kiN2jS3tz1bQqBXUjHSy9Yfb6iSFQN8ZvMTXSArTiqvaiI82+AnAX/N/9hjiWc1CkywcOuzh2/br8K6pcgXvo="

--- a/build-ci/eups_tutorial.rst
+++ b/build-ci/eups_tutorial.rst
@@ -28,7 +28,7 @@ Getting Started
 Having installed the stack, you already have EUPS available. However, its
 internal database is pre-populated with knowledge about the stack packages you
 have installed. For simplicity, we begin by re-targeting it by setting the
-:envvar:`EUPS_PATH` variable::
+``EUPS_PATH`` variable::
 
    % . ${STACK_PATH}/loadLSST.bash
    % eups path
@@ -67,8 +67,8 @@ Adding an EUPS Table File
 
 In order to make our package usable, we need EUPS to ensure:
 
-- That :file:`a.py` is on :envvar:`PYTHONPATH` (so that we can import it);
-- That :file:`bin/a` is on :envvar:`PATH` (so that we can execute it).
+- That :file:`a.py` is on ``PYTHONPATH`` (so that we can import it);
+- That :file:`bin/a` is on ``PATH`` (so that we can execute it).
 
 We communicate this to EUPS through a *table file*, located in the
 :file:`eups` directory within the product (in this case,

--- a/build-ci/lsstsw.rst
+++ b/build-ci/lsstsw.rst
@@ -168,7 +168,7 @@ again see the :file:`README` for details).
 
 The second command then takes the cloned repositories and the information in
 :file:`manifest.txt` and builds the products, installs them into the stack
-pointed to by :envvar:`EUPS_PATH`, and tags them with a "build ID" (a unique
+pointed to by ``EUPS_PATH``, and tags them with a "build ID" (a unique
 ID computed for each :file:`manifest.txt`, and listed in the
 :file:`manifest.txt` itself as ``BUILD=bNNN``). Therefore, running the two
 commands will build and install a complete, functioning stack for you. The log
@@ -224,7 +224,7 @@ and the distribution server. The old tools (e.g., :command:`submitRelease`,
 The new (automated) workflow is as follows:
 
 #. The new ``lsst-dev`` stack is in :file:`~lsstsw/stack`. Set your
-   :envvar:`EUPS_PATH` to point to it.
+   ``EUPS_PATH`` to point to it.
 
 #. :command:`lsst-build` right now periodically runs from :command:`cron` and
    builds the ``master`` branch any time it changes. The results end up in

--- a/build-ci/third_party.rst
+++ b/build-ci/third_party.rst
@@ -76,11 +76,11 @@ when you :command:`setup` your package.  Consider the table file for the
 This tells EUPS that, in order to setup the ``sphgeom`` package, it must also
 setup the packages ``base``, ``sconsUtils`` and ``doxygen``.  Furthermore, it
 adds the location of the ``sphgeom`` package (stored in the environment
-variable :envvar:`PRODUCT_DIR` at build time) to the environment variables
-:envvar:`PYTHONPATH`, :envvar:`LD_LIBRARY_PATH`, :envvar:`DYLD_LIBRARY_PATH`,
-:envvar:`LSST_LIBRARY_PATH`. These three environment variables are usually set
+variable ``PRODUCT_DIR`` at build time) to the environment variables
+``PYTHONPATH``, ``LD_LIBRARY_PATH``, ``DYLD_LIBRARY_PATH``,
+``LSST_LIBRARY_PATH``. These three environment variables are usually set
 for any installed package. We use the pre-defined ``envPrepend`` command so
-that the new :envvar:`PRODUCT_DIR` is prepended to the environment variables
+that the new ``PRODUCT_DIR`` is prepended to the environment variables
 and does not interfere with the non-stack system of libraries.
 
 :file:`eupspkg.cfg.sh`
@@ -92,7 +92,7 @@ to figure out how to install your package just based on the contents of the
 gzipped tarball in :file:`upstream/`. Sometimes, however, you will need to
 pass some additional commands in by hand. A simple version of this can be seen
 in the :file:`eupspkg.cfg.sh` for the `GalSim`_ package, which passes
-instructions to the `SCons`_ build system using the :envvar:`SCONSFLAGS`
+instructions to the `SCons`_ build system using the ``SCONSFLAGS``
 environment variable::
 
     export SCONSFLAGS=$SCONSFLAGS" USE_UNKNOWN_VARS=true TMV_DIR="$TMV_DIR" \

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -403,7 +403,7 @@ This is also consistent with :pep:`8` which states:
 
    Comparisons to singletons like ``None`` should always be done with ``is`` or ``is not``, never the equality operators.
 
-For sequences, (:py:class:`str`, :py:class:`list`, :py:class:`tuple`), use the fact that empty sequences are ``False``. 
+For sequences, (`str`, `list`, `tuple`), use the fact that empty sequences are ``False``. 
 
 Yes:
 
@@ -508,7 +508,7 @@ Yes:
    if type(obj) is type(1):
        pass
 
-When checking if an object is a string, keep in mind that it might be a unicode string too! Starting with Python 2.3, :py:class:`str` and :py:class:`unicode` have a common base class, :py:class:`basestring`, so you can do: 
+When checking if an object is a string, keep in mind that it might be a unicode string too! Starting with Python 2.3, `str` and `unicode` have a common base class, `basestring`, so you can do: 
 
 .. code-block:: py
 
@@ -576,7 +576,7 @@ Do not use features that are not available in these versions of Python.
 Python 2.5 improved Exception Handling SHOULD be used
 -----------------------------------------------------
 
-To catch all errors but let :py:exc:`SystemExit` and :py:exc:`KeyboardInterrupt` through, use:
+To catch all errors but let :py:exc:`~exceptions.SystemExit` and :py:exc:`~exceptions.KeyboardInterrupt` through, use:
 
 .. code-block:: py
 
@@ -610,7 +610,7 @@ The ``subprocess`` module SHOULD be used to spawn processes
 -----------------------------------------------------------
 
 Use the :py:mod:`subprocess` module to spawn processes.
-This supersedes and unifies :py:func:`os.system`, :py:func:`os.spawn`, :py:func:`os.popen`, etc..
+This supersedes and unifies :py:func:`os.system`, ``os.spawn``, :py:func:`os.popen`, etc..
 New in Python 2.3.
 
 .. _style-guide-py-9-2:

--- a/coding/unit_test_policy.rst
+++ b/coding/unit_test_policy.rst
@@ -87,21 +87,20 @@ C++: boost.test
 Python: unittest
     LSST DM developers should use `Python's unittest framework`_.
 
-    :mod:`lsst.utils.tests` provides several utilities for writing Python tests
+    ``lsst.utils.tests`` provides several utilities for writing Python tests
     that developers should make use of. In particular,
-    :class:`lsst.utils.tests.MemoryTestCase` is used to detect memory leaks in
-    C++ objects. :class:`~lsst.utils.tests.MemoryTestCase` should be used in
-    *all* tests, even if C++ code is not explicitly referenced.
+    ``lsst.utils.tests.MemoryTestCase`` is used to detect memory leaks in C++
+    objects. ``MemoryTestCase`` should be used in *all* tests, even if C++ code
+    is not explicitly referenced.
 
     This example shows the basic structure of an LSST Python unit test module,
-    including :class:`~lsst.utils.tests.MemoryTestCase`:
+    including ``lsst.utils.tests.MemoryTestCase``:
 
     .. literalinclude:: unit_test_snippets/unittest_runner_example.py
        :language: python
        :emphasize-lines: 21
 
-    Note that :class:`~lsst.utils.tests.MemoryTestCase` must always be the
-    final test suite.
+    Note that ``MemoryTestCase`` must always be the final test suite.
 
 .. _single-header variant: http://www.boost.org/doc/libs/1_60_0/libs/test/doc/html/boost_test/usage_variants.html#boost_test.usage_variants.single_header
 .. _Boost Unit Test Framework: http://www.boost.org/doc/libs/1_60_0/libs/test/doc/html/index.html

--- a/docs/rst_styleguide.rst
+++ b/docs/rst_styleguide.rst
@@ -67,8 +67,10 @@ Filenames and paths
 Shell commands
    ``:command:`git rebase -i master``` → :command:`git rebase -i master`
 
-Environment variables
-   ``:envvar:`EUPS_PATH``` → :envvar:`EUPS_PATH`
+..
+  FIXME need to clarify that this is actual for linking, no semantics
+  Environment variables
+     ``:envvar:`EUPS_PATH``` → :envvar:`EUPS_PATH`
 
 User interface labels
    ``:guilabel:`New Pull Request``` → :guilabel:`New Pull Request`. This markup can be used for button labels, menus, or even text labels in interactive shell programs.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Sphinx>=1.3.1
+Sphinx>=1.4.1
 sphinx-prompt==1.0.0
 sphinx-rtd-theme


### PR DESCRIPTION
This PR adds a Travis configuration to build the developer guide and publish to LSST the Docs (at developer.lsst.io).

Minor changes to existing reference syntax was required because of the move to nit-picky builds (see https://ltd-mason.lsst.io/travis.html#travis-setup-for-a-pure-sphinx-repository) to help ensure that intended code references do in fact resolve in successful builds. References to code objects in the `lsst` namespace can be re-added in the future.