### PR TITLE
DM-6326: Add documenteer package for LSST Sphinx extensions

### DIFF
--- a/coding/unit_test_policy.rst
+++ b/coding/unit_test_policy.rst
@@ -87,14 +87,14 @@ C++: boost.test
 Python: unittest
     LSST DM developers should use `Python's unittest framework`_.
 
-    ``lsst.utils.tests`` provides several utilities for writing Python tests
+    :lmod:`lsst.utils.tests` provides several utilities for writing Python tests
     that developers should make use of. In particular,
-    ``lsst.utils.tests.MemoryTestCase`` is used to detect memory leaks in C++
-    objects. ``MemoryTestCase`` should be used in *all* tests, even if C++ code
+    :lclass:`lsst.utils.tests.MemoryTestCase` is used to detect memory leaks in C++
+    objects. :lclass:`~lsst.utils.tests.MemoryTestCase` should be used in *all* tests, even if C++ code
     is not explicitly referenced.
 
     This example shows the basic structure of an LSST Python unit test module,
-    including ``lsst.utils.tests.MemoryTestCase``:
+    including :lclass:`~lsst.utils.tests.MemoryTestCase`:
 
     .. literalinclude:: unit_test_snippets/unittest_runner_example.py
        :language: python

--- a/conf.py
+++ b/conf.py
@@ -42,6 +42,7 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinx-prompt',
+    'documenteer.sphinxext'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Sphinx>=1.4.1
-sphinx-prompt==1.0.0
 sphinx-rtd-theme
+documenteer>=0.1.4


### PR DESCRIPTION
`documenteer.sphinxext` gives us mock versions of Python references roles so that LSST code can be marked-up semantically in a way that'll be easy to transition once the Pipelines docs are published with sphinx.

These roles are the standard code reference roles, just preprended with `l`, as in 'lsst.'
E.g.

```
:lclass:`~lsst.utils.tests.MemoryTestCase`
```