### PR TITLE
Add lfs batch config lines

### DIFF
--- a/tools/git_lfs.rst
+++ b/tools/git_lfs.rst
@@ -219,7 +219,7 @@ In the repository's :file:`README`, we recommend that you include this section:
 
    To clone and use this repository, you'll need Git Large File Storage (LFS).
 
-   Our [Developer Guide](http://developer.lsst.io/tools/git_lfs.html)
+   Our [Developer Guide](https://developer.lsst.io/tools/git_lfs.html)
    explains how to set up Git LFS for LSST development.
 
 .. _Homebrew: http://brew.sh

--- a/tools/git_lfs.rst
+++ b/tools/git_lfs.rst
@@ -219,7 +219,7 @@ In the repository's :file:`README`, we recommend that you include this section:
 
    To clone and use this repository, you'll need Git Large File Storage (LFS).
 
-   Our [Developer Guide](http://developer.lsst.io/en/latest/tools/git_lfs.html)
+   Our [Developer Guide](http://developer.lsst.io/tools/git_lfs.html)
    explains how to set up Git LFS for LSST development.
 
 .. _Homebrew: http://brew.sh

--- a/tools/git_lfs.rst
+++ b/tools/git_lfs.rst
@@ -52,6 +52,8 @@ First, add these lines into your :file:`~/.gitconfig` file:
 
 .. literalinclude:: snippets/git_lfs_gitconfig.txt
    :language: text
+   
+*(This example includes the result of the lfs.batch false configuration command.)*
 
 Then add these lines into your :file:`~/.git-credentials` files (create one, if necessary):
 
@@ -74,7 +76,9 @@ First, add these lines into your :file:`~/.gitconfig` file:
 
 .. literalinclude:: snippets/git_lfs_gitconfig.txt
    :language: text
-   :lines: 1-5
+   :lines: 1-8
+
+*(This example includes the result of the lfs.batch false configuration command.)*
 
 Then add these lines into your :file:`~/.git-credentials` files (create one, if necessary):
 

--- a/tools/git_lfs.rst
+++ b/tools/git_lfs.rst
@@ -53,7 +53,7 @@ First, add these lines into your :file:`~/.gitconfig` file:
 .. literalinclude:: snippets/git_lfs_gitconfig.txt
    :language: text
    
-*(This example includes the result of the lfs.batch false configuration command.)*
+*(This example includes the result of the earlier 'lfs.batch false' configuration command.)*
 
 Then add these lines into your :file:`~/.git-credentials` files (create one, if necessary):
 
@@ -78,7 +78,7 @@ First, add these lines into your :file:`~/.gitconfig` file:
    :language: text
    :lines: 1-8
 
-*(This example includes the result of the lfs.batch false configuration command.)*
+*(This example includes the result of the earlier 'lfs.batch false' configuration command.)*
 
 Then add these lines into your :file:`~/.git-credentials` files (create one, if necessary):
 

--- a/tools/snippets/git_lfs_gitconfig.txt
+++ b/tools/snippets/git_lfs_gitconfig.txt
@@ -1,3 +1,6 @@
+[lfs]
+    batch = false
+
 # Cache anonymous access to DM Git LFS S3 servers
 [credential "https://lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com"]
     helper = store


### PR DESCRIPTION
The purpose of this change is to repeat the result from a git config --global lfs.batch false to remind folks that this configuration is needed in case the earlier documentation lines were skipped. See
https://community.lsst.org/t/issues-using-git-lfs-for-cloning-test-data-repositories/880/16?u=jsick

https://developer.lsst.io/v/u-jonathansick-git-lfs-doc/tools/git_lfs.html