### PR TITLE
DM-5456: Python Style Guide as a diff of PEP 8 and accept Numpydoc

### DIFF
--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -251,148 +251,50 @@ Other subtleties have been noted in https://fuhm.net/super-harmful/:
 
 .. _style-guide-py-files:
 
-4. Files
-========
+4. Source Files & Modules
+=========================
 
-.. _style-guide-py-4-1:
+.. _style-guide-py-file-name:
 
-A Python source file name SHOULD be camelCase-with-leading-lowercase and ending in ``.py``
-------------------------------------------------------------------------------------------
+A Python source file name SHOULD be camelCase-with-leading-lowercase and ending in '.py'
+----------------------------------------------------------------------------------------
 
-The name of a file containing a module will be the ``camelCase``-with-leading-lowercase transliteration of the module name.
+A module containing a single class should be a ``camelCase``-with-leading-lowercase transliteration of the class's name.
+
 The name of a test case should be descriptive without the need for a trailing numeral to distinguish one test case from another. 
 
-.. _style-guide-py-4-2:
+.. TODO consider refactoring tests into their own section
+
+.. _style-guide-py-file-encoding:
 
 ASCII Encoding MUST be used for new code
 ----------------------------------------
 
-- Always use ASCII for new python code.
+Always use ASCII for new python code.
 
 - **Do not** include a coding comment (as described in  :pep:`263`) for ASCII files.
 
 - Existing code using Latin-1 encoding (a.k.a. ISO-8859-1) is acceptable so long as it has a proper coding comment. All other code must be converted to ASCII or Latin-1 except for 3rd party packages used "as is."
 
-.. _style-guide-py-4-3:
+.. _style-guide-py-file-order:
 
-DM specified code order SHOULD be followed
-------------------------------------------
+Standard code order SHOULD be followed
+--------------------------------------
 
 Within a module, follow the order: 
 
-1. Shebang line (``#!``), only for executable scripts
-2. Module-level comments
+1. Shebang line, ``#! /usr/bin/env python`` (only for executable scripts)
+2. Module-level comments (such as the `license statement <https://github.com/lsst/templates/blob/master/CopyrightHeader.py>`__)
 3. Module-level docstring
 4. Imports
 5. ``__all__`` statement, if any
-6. Module variables (names start with underscore)
-7. Module functions and classes (names start with underscore)
-8. Public variables
+6. Private module variables (names start with underscore)
+7. Private module functions and classes (names start with underscore)
+8. Public module variables
 9. Public functions and classes
 10. Optional test suites
 
-.. _style-guide-py-4-4:
-
-Imports SHOULD be grouped, in order: standard lib, 3rd party lib, local lib
----------------------------------------------------------------------------
-
-Imports should be grouped in the following order, with each group separated by a blank line:
-
-1. standard library imports
-2. related third party imports
-3. local application/library specific imports
-
-When importing a class from a class-containing module,
-it's usually okay to do this:
-
-.. code-block:: py
-
-   from myclass import MyClass
-   from foo.bar.yourclass import YourClass
-
-But if that causes local name clashes, then do this instead: 
-
-.. code-block:: py
-
-   import myclass
-   import foo.bar.yourclass
-
-and use ``myclass.MyClass`` and ``foo.bar.yourclass.YourClass``. 
-
-Relative imports SHOULD be used when importing another module from the same package
-Consider this layout: 
-
-.. code-block:: text
-
-   mypkg/
-       __init__.py
-       foo.py
-       bar.py
-
-If ``foo`` wants to import ``bar``, the safe way to do this (Python 2.6 and later) is to use relative import:
-
-.. code-block:: py
-
-   from . import bar
-
-Or, if you just want a few symbols from bar, this also works:
-
-.. code-block:: py
-
-   from .bar import thing1, thing2
-
-This avoids any danger of name collision with a module on the python path named bar.
-Relative import statements are richer than suggested by the example; see :pep:`328` for details.
-
-.. _style-guide-py-4-5:
-
-Multiple Statements SHOULD NOT occur on same Line
--------------------------------------------------
-
-Compound statements (multiple statements on the same line) are generally discouraged.
-
-Yes: 
-
-.. code-block:: py
-
-   if foo == 'blah':
-       do_blah_thing()
-       do_one()
-       do_two()
-       do_three()
-
-No:
-
-.. code-block:: py
-
-   if foo == 'blah': do_blah_thing()
-       do_one(); do_two(); do_three()
-
-While sometimes it's okay to put an ``if``/``for``/``while`` with a small body on the same line, never do this for multi-clause statements.
-Also avoid folding such long lines!
-
-Rather not:
-
-.. code-block:: py
-
-   if foo == 'blah': do_blah_thing()
-   for x in lst: total += x
-   while t < 10: t = delay()
-
-Definitely not:
-
-.. code-block:: py
-
-   if foo == 'blah': do_blah_thing()
-   else: do_non_blah_thing()
- 
-   try: something()
-   finally: cleanup()
- 
-   do_one(); do_two(); do_three(long, argument,
-                                list, like, this)
-                            
-   if foo == 'blah': one(); two(); three()
+.. note:: Delete mention of test suites?
 
 .. _style-guide-py-string-handling:
 

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -149,455 +149,10 @@ Style changes must be encapsulated in a distinct commit (see :ref:`git-commit-or
 
 .. _autopep8: https://pypi.python.org/pypi/autopep8
 
-.. _style-guide-py-naming:
-
-2. Naming Conventions
-=====================
-
-We follow `PEP 8ʼs naming conventions <https://www.python.org/dev/peps/pep-0008/#naming-conventions>`_, with exceptions listed here.
-The naming conventions for LSST Python and C++ source have been defined to be as similar as the respective languages allow.
-
-In general:
-
-- class names are ``CamelCase`` with leading uppercase,
-- module variables used as module global constants are ``UPPERCASE_WITH_UNDERSCORES``,
-- all other names are ``camelCase`` with leading lowercase.
-
-Names may be decorated with leading and/or trailing underscores.
-
-.. _style-guide-py-2-2:
-
-User defined names SHOULD NOT shadow python built-in functions
---------------------------------------------------------------
-
-Names which shadow a python built-in function may cause confusion for readers of the code.
-Creating a more specific identifier is suggested to avoid collisions.
-In the case of *filter*, ``filterName`` may be appropriate; for *filter objects*, something like ``filterObj`` might be appropriate.
-
-.. _style-guide-py-naming-attributes:
-
-Class Attribute Names SHOULD be camelCase with leading lowercase
-----------------------------------------------------------------
-
-`Opposes PEP 8 <https://www.python.org/dev/peps/pep-0008/#id45>`__.
-Error codes: N802 and N803.
-
-.. _style-guide-py-naming-functions:
-
-Module methods (free functions) SHOULD be camelCase with leading lowercase
---------------------------------------------------------------------------
-
-`Opposes PEP 8 <https://www.python.org/dev/peps/pep-0008/#id45>`__.
-Error code: N802.
-
-.. _style-guide-py-naming-class-modules:
-
-Modules which contain class definitions SHOULD be named after the class name
-----------------------------------------------------------------------------
-
-Modules which contain class definitions should be named after the class name (one module per class).
-
-.. _style-guide-py-naming-ext-modules:
-
-When a Python module wraps a C/C++ extension module, the C/C++ module SHOULD be named <module>Lib
--------------------------------------------------------------------------------------------------
-
-When an extension module written in C or C++ has an accompanying Python module that provides a higher level (e.g. more object oriented) interface, the C/C++ module should append ``Lib`` to the module's name (e.g. ``socketLib``).
-
-.. _style-guide-py-naming-ambiguous:
-
-Names l (lowercase: el), O (uppercase: oh), I (uppercase: eye) MUST be avoided
-------------------------------------------------------------------------------
-
-Never use these characters as single character variable names:
-
-- ``l`` (lowercase letter el),
-- ``O`` (uppercase letter oh), or
-- ``I`` (uppercase letter eye).
-
-In some fonts, these characters are indistinguishable from the numerals one and zero.
-When tempted to use ``l``, use ``L`` instead.
-
-.. _style-guide-py-inheritance:
-
-3. Designing for Inheritance
-============================
-
-Always decide whether a class's methods and instance variables (collectively: "attributes") should be public or non-public.
-If in doubt, choose non-public; it's easier to make it public later than to make a public attribute non-public.
-
-Public attributes are those that you expect unrelated clients of your class to use, with your commitment to avoid backward incompatible changes.
-Non-public attributes are those that are not intended to be used by third parties; you make no guarantees that non-public attributes won't change or even be removed.
-
-We don't use the term "private" here, since no attribute is really private in Python (without a generally unnecessary amount of work).
-Another category of attributes are those that are part of the "subclass API" (often called "protected" in other languages).
-Some classes are designed to be inherited from, either to extend or modify aspects of the class's behavior.
-When designing such a class, take care to make explicit decisions about which attributes are public, which are part of the subclass API, and which are truly only to be used by your base class.
-
-For simple public data attributes, it is best to expose just the attribute name, without complicated accessor/mutator methods.
-Keep in mind that Python provides an easy path to future enhancement, should you find that a simple data attribute needs to grow functional behavior.
-In that case, use properties to hide functional implementation behind simple data attribute access syntax.
-
-- Note 1: Properties only work on new-style classes.
-
-- Note 2: Try to keep the functional behavior side-effect free, although side-effects such as caching are generally fine.
-
-- Note 3: Avoid using properties for computationally expensive operations; the attribute notation makes the caller believe that access is (relatively) cheap.
-
-.. _style-guide-py-super:
-
-``super`` SHOULD NOT be used unless the author really understands the implications (e.g. in a well-understood multiple inheritance hierarchy).
-----------------------------------------------------------------------------------------------------------------------------------------------
-
-Python provides ``super`` so that each parent class' method is only called once (see https://www.python.org/download/releases/2.3/mro/).
-The problem is, if you're going to use super at all, then all parent classes in the chain (also called the Method Resolution Order") need to use super otherwise the chain gets interrupted. 
-Other subtleties have been noted in https://fuhm.net/super-harmful/:
-
-- Never call super with anything but the exact arguments you received, unless you really know what you're doing.
-- When you use it on methods whose acceptable arguments can be altered on a subclass via addition of more optional arguments, always accept ``*args, **kw``, and call ``super`` like ``super(MyClass, self).currentmethod(alltheargsideclared, *args, **kwargs)``.
-  If you don't do this, forbid addition of optional arguments in subclasses.
-- Never use positional arguments in ``__init__`` or ``__new__``.
-  Always use keyword args, and always call them as keywords, and always pass all keywords on to ``super``.
-
-.. _style-guide-py-files:
-
-4. Source Files & Modules
-=========================
-
-.. _style-guide-py-file-name:
-
-A Python source file name SHOULD be camelCase-with-leading-lowercase and ending in '.py'
-----------------------------------------------------------------------------------------
-
-A module containing a single class should be a ``camelCase``-with-leading-lowercase transliteration of the class's name.
-
-The name of a test case should be descriptive without the need for a trailing numeral to distinguish one test case from another. 
-
-.. TODO consider refactoring tests into their own section
-
-.. _style-guide-py-file-encoding:
-
-ASCII Encoding MUST be used for new code
-----------------------------------------
-
-Always use ASCII for new python code.
-
-- **Do not** include a coding comment (as described in  :pep:`263`) for ASCII files.
-
-- Existing code using Latin-1 encoding (a.k.a. ISO-8859-1) is acceptable so long as it has a proper coding comment. All other code must be converted to ASCII or Latin-1 except for 3rd party packages used "as is."
-
-.. _style-guide-py-file-order:
-
-Standard code order SHOULD be followed
---------------------------------------
-
-Within a module, follow the order: 
-
-1. Shebang line, ``#! /usr/bin/env python`` (only for executable scripts)
-2. Module-level comments (such as the `license statement <https://github.com/lsst/templates/blob/master/CopyrightHeader.py>`__)
-3. Module-level docstring
-4. Imports
-5. ``__all__`` statement, if any
-6. Private module variables (names start with underscore)
-7. Private module functions and classes (names start with underscore)
-8. Public module variables
-9. Public functions and classes
-10. Optional test suites
-
-.. note:: Delete mention of test suites?
-
-.. _style-guide-py-comparisons:
-
-5. Comparisons
-==============
-
-.. _style-guide-py-comp-is:
-
-``is`` and ``is not`` SHOULD only be used if determining if two variables point to same object
-----------------------------------------------------------------------------------------------
-
-Use ``is`` or ``is not`` only for the case that you need to know that two variables point to the exact same object.
-
-To test equality in *value*, use ``==`` or ``!=`` instead.
-
-.. _style-guide-py-comp-none:
-
-``is`` and ``is not`` SHOULD be used when comparing to ``None``
----------------------------------------------------------------
-
-There are two reasons:
-
-1. ``is None`` works with NumPy arrays, whereas ``== None`` does not;
-2. ``is None`` is idiomatic.
-
-This is also consistent with :pep:`8`, which `states <https://www.python.org/dev/peps/pep-0008/#id49>`__:
-
-   Comparisons to singletons like ``None`` should always be done with ``is`` or ``is not``, never the equality operators.
-
-For sequences, (`str`, `list`, `tuple`), use the fact that empty sequences are ``False``. 
-
-Yes:
-
-.. code-block:: py
-
-   if not seq:
-       pass
-
-   if seq:
-       pass
-
-No:
-
-.. code-block:: py
-
-   if len(seq):
-       pass
-
-   if not len(seq):
-       pass
-
-.. _style-guide-py-pitfalls:
-
-6. Programming Pitfalls
-=======================
-
-.. _style-guide-py-pitfalls-mutables:
-
-A mutable object MUST NOT be used as a keyword argument default
----------------------------------------------------------------
-
-Never use a mutable object as default value for a keyword argument in a function or method.
-
-When used a mutable is used as a default keyword argument, the default *can* change from one call to another leading to unexpected behavior.
-This issue can be avoided by only using immutable types as default.
-
-For example, rather than provide a default empty list:
-
-.. code-block:: py
-
-   def proclist(alist=[]):
-       pass
-
-this function should create a new list in its internal scope:
-
-.. code-block:: py
-
-   def proclist(alist=None):
-       if alist is None:
-           alist = []
-
-.. _style-guide-py-pitfalls-star-args:
-
-In function calls ``*`` SHOULD be used instead of ``apply``
----------------------------------------------------------------
-
-In old versions of Python, to call a function with an argument list and/or keyword dictionary you had to write ``apply(func, args, keyargs)``.
-Now you can write ``func(*args, keyargs)``, which is faster and clearer.
-
-.. _style-guide-py-recommendations:
-
-7. Programming Recommendations
-==============================
-
-Try to make your Python code idiomatic (*pythonic*).
-Consider the following, slightly adapted from Tim Peters' `The Zen of Python <http://www.python.org/dev/peps/pep-0020>`_:
-
-| Beautiful is better than ugly. 
-| Explicit is better than implicit. 
-| Simple is better than complex. 
-| Complex is better than complicated. 
-| Flat is better than nested. 
-| Sparse is better than dense. 
-| Readability counts. 
-| Special cases aren't special enough to break the rules. 
-| Although practicality beats purity. 
-| Errors should never pass silently. 
-| Unless explicitly silenced. 
-| In the face of ambiguity, refuse the temptation to guess. 
-| There should be one---and preferably only one---obvious way to do it. 
-| If the implementation is hard to explain, it's a bad idea. 
-| If the implementation is easy to explain, it may be a good idea.
-
-.. _style-guide-py-idiomatic-python:
-
-Idiomatic modern Python SHOULD be used
---------------------------------------
-
-The Python language has evolved with time.
-Learn the new features of Python and use them where appropriate to make your code simpler and more readable.
-For example:
-
-- Use iterators, generators (classes that act like iterators) and generator expressions (expressions that act like iterators) to iterate over large data sets efficiently.
-  (New in Python 2.2, except generator expressions were added in 2.4 and generators were slightly enhanced in Python 2.5.)
-
-- Use the ``with`` statement to simplify resource allocation.
-  (New in Python 2.5.)
-  For example to be sure a file will be closed when you are done with it: 
-  
-  .. code-block:: py
-
-     with open('/etc/passwd', 'r') as f:
-         for line in f:
-             pass
-
-The LSST environment currently supports Python 2.7.x.
-Do not use features that are not available in these versions of Python.
-
-.. _style-guide-py-exception-handling-syntax:
-
-Python 2.5 improved Exception Handling SHOULD be used
------------------------------------------------------
-
-To catch all errors but let :py:exc:`~exceptions.SystemExit` and :py:exc:`~exceptions.KeyboardInterrupt` through, use:
-
-.. code-block:: py
-
-   except Exception, e:
-       pass
-
-The exception hierarchy in Python 2.5 was improved, eliminating the need to use this: 
-
-.. code-block:: py
-
-   except (SystemExit, KeyboardInterrupt):
-       raise
-       except Exception, e:
-           pass
-
-.. _style-guide-py-suggested-modules:
-
-8. Suggested Modules
-====================
-
-.. _style-guide-py-subprocess:
-
-The ``subprocess`` module SHOULD be used to spawn processes
------------------------------------------------------------
-
-Use the :py:mod:`subprocess` module to spawn processes.
-This supersedes and unifies :py:func:`os.system`, ``os.spawn``, :py:func:`os.popen`, etc..
-New in Python 2.3.
-
-.. _style-guide-py-lambda:
-
-``lambda`` SHOULD NOT be used
------------------------------
-
-Avoid the use of ``lambda``.
-You can almost always write clearer code by using a named function or using the :py:mod:`functools` module to wrap a function.
-
-.. _style-guide-py-set:
-
-The ``set`` type SHOULD be used for unordered collections
----------------------------------------------------------
-
-Use the :py:class:`set` type for unordered collections of objects.
-New in Python 2.4 (though available via the ``Set`` module in Python 2.3).
-
-.. _style-guide-py-argparse:
-
-The ``argparse`` module SHOULD be used for command-line scripts 
----------------------------------------------------------------
-
-Use the :py:mod:`argparse` module for command-line scripts.
-
-Command line tasks for pipelines should use :lclass:`lsst.pipe.base.ArgumentParser` instead.
-
-.. _style-guide-py-py3:
-
-9. Python 3 Idioms
-==================
-
-It is possible to write much of the Python code in a way that will run well under both Python 2.7 and Python 3.x, without harming readability (and in some cases, improving it).
-There are other cases where code can be written in a way that helps the futurize_ code converter produce more efficient code.
-
-For more information see http://python3porting.com/toc.html, among several useful references.
-
-.. _futurize: http://python-future.org/futurize.html
-
-.. _style-guide-py-future-division:
-
-Use ``from __future__ import division``
----------------------------------------
-
-This means ``/`` is floating-point division and ``//`` is truncated integer division, regardless of the type of numbers being divided.
-This gives more predictable behavior than the old operators, avoiding a common source of obscure bugs.
-It also makes intent of the code more obvious.
-
-.. _style-guide-py-future-absolute-import:
-
-Use ``from __future__ import absolute_import``
-----------------------------------------------
-
-In addition, import local modules using relative imports (e.g. ``from . import foo`` or ``from .foo import bar``).
-This results in clearer code and avoids shadowing global modules with local modules.
-
-.. _style-guide-py-future-itervalues:
-
-Use ``itervalues()`` and ``iteritems()`` instead of ``values()`` and ``items()``
---------------------------------------------------------------------------------
-
-For iterating over dictionary values and items use the above idiom unless you truly need a list.
-This generates more efficient code today and helps futurize_ generate more efficient code in the future.
-For more information see http://python-future.org/compatible_idioms.html#iterating-through-dict-keys-values-items.
-
-.. _style-guide-py-dict-keys:
-
-Avoid ``dict.keys()`` and ``dict.iterkeys()``
----------------------------------------------
-
-For iterating over keys, iterate over the dictionary itself, e.g.:
-
-.. code-block:: py
-
-   for x in mydict:
-       pass
-   
-To test for inclusion use ``in``:
-
-.. code-block:: py
-
-    if key in myDict:
-        pass
-    
-This is preferred over ``keys()`` and ``iterkeys()`` and avoids the issues mentioned in the previous item.
-
-.. _style-guide-py-open:
-
-Replace ``file`` with ``open``
-------------------------------
-
-This is preferred and ``file`` is gone in Python 3.
-
-.. _style-guide-py-exception-as:
-
-Use ``as`` when catching an exception
--------------------------------------
-
-For example, use ``except Exception as e`` or ``except (LookupError, TypeError) as e``.
-The new syntax is clearer, especially when catching multiple exception classes, and the old syntax does not work in Python 3.
-
-.. note:: Conflicts with :ref:`style-guide-py-exception-handling-syntax`?
-
-.. _style-guide-py-print-function:
-
-Use from ``__future__ import print_function``
----------------------------------------------
-
-Minor, but provides forward compatibility.
-This will affect very little code since we rarely use print.
-
-.. _style-guide-py-next:
-
-Use ``next(myIter)`` instead of ``myIter.next()``
--------------------------------------------------
-
-This is preferred, and the special method ``next`` has been renamed to ``__next__`` in Python 3.
-
 .. _style-guide-py-layout:
 
-10. Layout
-==========
+2. Layout
+=========
 
 .. _style-guide-py-line-length:
 
@@ -661,8 +216,8 @@ Consistency with the LSST C++ Coding Standards namespaces exists.
 
 .. _style-guide-py-whitespace:
 
-11. Whitespace
-==============
+3. Whitespace
+=============
 
 Follow the `PEP 8 whitespace style guidelines <https://www.python.org/dev/peps/pep-0008/#id26>`_, with the following adjustments.
 
@@ -756,11 +311,11 @@ Not this:
 
 `Opposes PEP 8 <https://www.python.org/dev/peps/pep-0008/#id28>`__.
 Error code: N251.
- 
+
 .. _style-guide-py-comments:
 
-12. Comments
-============
+4. Comments
+===========
 
 Source code comments should follow `PEP 8's recommendations <https://www.python.org/dev/peps/pep-0008/#id29>`__ with the following additional requirements.
 
@@ -795,12 +350,12 @@ Paragraphs inside a block comment are separated by a line containing a single ``
 
 .. _style-guide-py-docstrings:
 
-13. Documentation Strings (docstrings)
-======================================
+5. Documentation Strings (docstrings)
+=====================================
 
 Use **Numpydoc** to format the content of all docstrings.
 The page :doc:`../docs/py_docs` authoritatively describes this format.
-It's guide should be treated as an extension of this Python style guide.
+Its guidelines should be treated as an extension of this Python style guide.
 
 See also the :doc:`../docs/rst_styleguide` and the :ref:`rst-formatting-guidelines` section in particular for guidelines on reStructuredText in general.
 
@@ -814,3 +369,416 @@ See :doc:`../docs/py_docs`.
 
 Docstrings are not necessary for non-public methods, but you should have a comment that describes what the method does.
 This comment should appear after the ``def`` line.
+
+.. _style-guide-py-naming:
+
+6. Naming Conventions
+=====================
+
+We follow `PEP 8ʼs naming conventions <https://www.python.org/dev/peps/pep-0008/#naming-conventions>`_, with exceptions listed here.
+The naming conventions for LSST Python and C++ source have been defined to be as similar as the respective languages allow.
+
+In general:
+
+- class names are ``CamelCase`` with leading uppercase,
+- module variables used as module global constants are ``UPPERCASE_WITH_UNDERSCORES``,
+- all other names are ``camelCase`` with leading lowercase.
+
+Names may be decorated with leading and/or trailing underscores.
+
+.. _style-guide-py-2-2:
+
+User defined names SHOULD NOT shadow python built-in functions
+--------------------------------------------------------------
+
+Names which shadow a python built-in function may cause confusion for readers of the code.
+Creating a more specific identifier is suggested to avoid collisions.
+In the case of *filter*, ``filterName`` may be appropriate; for *filter objects*, something like ``filterObj`` might be appropriate.
+
+.. _style-guide-py-naming-attributes:
+
+Class Attribute Names SHOULD be camelCase with leading lowercase
+----------------------------------------------------------------
+
+`Opposes PEP 8 <https://www.python.org/dev/peps/pep-0008/#id45>`__.
+Error codes: N802 and N803.
+
+.. _style-guide-py-naming-functions:
+
+Module methods (free functions) SHOULD be camelCase with leading lowercase
+--------------------------------------------------------------------------
+
+`Opposes PEP 8 <https://www.python.org/dev/peps/pep-0008/#id45>`__.
+Error code: N802.
+
+.. _style-guide-py-naming-class-modules:
+
+Modules which contain class definitions SHOULD be named after the class name
+----------------------------------------------------------------------------
+
+Modules which contain class definitions should be named after the class name (one module per class).
+
+.. _style-guide-py-naming-ext-modules:
+
+When a Python module wraps a C/C++ extension module, the C/C++ module SHOULD be named <module>Lib
+-------------------------------------------------------------------------------------------------
+
+When an extension module written in C or C++ has an accompanying Python module that provides a higher level (e.g. more object oriented) interface, the C/C++ module should append ``Lib`` to the module's name (e.g. ``socketLib``).
+
+.. _style-guide-py-naming-ambiguous:
+
+Names l (lowercase: el), O (uppercase: oh), I (uppercase: eye) MUST be avoided
+------------------------------------------------------------------------------
+
+Never use these characters as single character variable names:
+
+- ``l`` (lowercase letter el),
+- ``O`` (uppercase letter oh), or
+- ``I`` (uppercase letter eye).
+
+In some fonts, these characters are indistinguishable from the numerals one and zero.
+When tempted to use ``l``, use ``L`` instead.
+
+.. _style-guide-py-files:
+
+7. Source Files & Modules
+=========================
+
+.. _style-guide-py-file-name:
+
+A Python source file name SHOULD be camelCase-with-leading-lowercase and ending in '.py'
+----------------------------------------------------------------------------------------
+
+A module containing a single class should be a ``camelCase``-with-leading-lowercase transliteration of the class's name.
+
+The name of a test case should be descriptive without the need for a trailing numeral to distinguish one test case from another. 
+
+.. TODO consider refactoring tests into their own section
+
+.. _style-guide-py-file-encoding:
+
+ASCII Encoding MUST be used for new code
+----------------------------------------
+
+Always use ASCII for new python code.
+
+- **Do not** include a coding comment (as described in  :pep:`263`) for ASCII files.
+
+- Existing code using Latin-1 encoding (a.k.a. ISO-8859-1) is acceptable so long as it has a proper coding comment. All other code must be converted to ASCII or Latin-1 except for 3rd party packages used "as is."
+
+.. _style-guide-py-file-order:
+
+Standard code order SHOULD be followed
+--------------------------------------
+
+Within a module, follow the order: 
+
+1. Shebang line, ``#! /usr/bin/env python`` (only for executable scripts)
+2. Module-level comments (such as the `license statement <https://github.com/lsst/templates/blob/master/CopyrightHeader.py>`__)
+3. Module-level docstring
+4. Imports
+5. ``__all__`` statement, if any
+6. Private module variables (names start with underscore)
+7. Private module functions and classes (names start with underscore)
+8. Public module variables
+9. Public functions and classes
+10. Optional test suites
+
+.. FIXME JSick: Delete mention of test suites?
+
+.. _style-guide-py-classes:
+
+8. Classes
+==========
+
+Always decide whether a class's methods and instance variables (collectively: "attributes") should be public or non-public.
+If in doubt, choose non-public; it's easier to make it public later than to make a public attribute non-public.
+
+Public attributes are those that you expect unrelated clients of your class to use, with your commitment to avoid backward incompatible changes.
+Non-public attributes are those that are not intended to be used by third parties; you make no guarantees that non-public attributes won't change or even be removed.
+
+We don't use the term "private" here, since no attribute is really private in Python (without a generally unnecessary amount of work).
+Another category of attributes are those that are part of the "subclass API" (often called "protected" in other languages).
+Some classes are designed to be inherited from, either to extend or modify aspects of the class's behavior.
+When designing such a class, take care to make explicit decisions about which attributes are public, which are part of the subclass API, and which are truly only to be used by your base class.
+
+For simple public data attributes, it is best to expose just the attribute name, without complicated accessor/mutator methods.
+Keep in mind that Python provides an easy path to future enhancement, should you find that a simple data attribute needs to grow functional behavior.
+In that case, use properties to hide functional implementation behind simple data attribute access syntax.
+
+- Note 1: Properties only work on new-style classes.
+
+- Note 2: Try to keep the functional behavior side-effect free, although side-effects such as caching are generally fine.
+
+- Note 3: Avoid using properties for computationally expensive operations; the attribute notation makes the caller believe that access is (relatively) cheap.
+
+.. _style-guide-py-super:
+
+``super`` SHOULD NOT be used unless the author really understands the implications (e.g. in a well-understood multiple inheritance hierarchy).
+----------------------------------------------------------------------------------------------------------------------------------------------
+
+Python provides ``super`` so that each parent class' method is only called once (see https://www.python.org/download/releases/2.3/mro/).
+The problem is, if you're going to use super at all, then all parent classes in the chain (also called the Method Resolution Order") need to use super otherwise the chain gets interrupted. 
+Other subtleties have been noted in https://fuhm.net/super-harmful/:
+
+- Never call super with anything but the exact arguments you received, unless you really know what you're doing.
+- When you use it on methods whose acceptable arguments can be altered on a subclass via addition of more optional arguments, always accept ``*args, **kw``, and call ``super`` like ``super(MyClass, self).currentmethod(alltheargsideclared, *args, **kwargs)``.
+  If you don't do this, forbid addition of optional arguments in subclasses.
+- Never use positional arguments in ``__init__`` or ``__new__``.
+  Always use keyword args, and always call them as keywords, and always pass all keywords on to ``super``.
+
+
+.. _style-guide-py-comparisons:
+
+9. Comparisons
+==============
+
+.. _style-guide-py-comp-is:
+
+``is`` and ``is not`` SHOULD only be used if determining if two variables point to same object
+----------------------------------------------------------------------------------------------
+
+Use ``is`` or ``is not`` only for the case that you need to know that two variables point to the exact same object.
+
+To test equality in *value*, use ``==`` or ``!=`` instead.
+
+.. _style-guide-py-comp-none:
+
+``is`` and ``is not`` SHOULD be used when comparing to ``None``
+---------------------------------------------------------------
+
+There are two reasons:
+
+1. ``is None`` works with NumPy arrays, whereas ``== None`` does not;
+2. ``is None`` is idiomatic.
+
+This is also consistent with :pep:`8`, which `states <https://www.python.org/dev/peps/pep-0008/#id49>`__:
+
+   Comparisons to singletons like ``None`` should always be done with ``is`` or ``is not``, never the equality operators.
+
+For sequences, (`str`, `list`, `tuple`), use the fact that empty sequences are ``False``. 
+
+Yes:
+
+.. code-block:: py
+
+   if not seq:
+       pass
+
+   if seq:
+       pass
+
+No:
+
+.. code-block:: py
+
+   if len(seq):
+       pass
+
+   if not len(seq):
+       pass
+
+.. _style-guide-py-idioms:
+
+10. Idiomatic Python
+====================
+
+Strive to write idiomatic Python.
+Writing Python with accepted patterns makes your code easier for others to understand and often prevents bugs.
+
+`Fluent Python <http://shop.oreilly.com/product/0636920032519.do>`_ by Luciano Ramalho is an excellent guide to writing idiomatic Python.
+
+Idiomatic Python also reduces technical debt, particularly by easing the migration from Python 2.7 to Python 3.
+Codes should be written in a way that helps the futurize_ code converter produce more efficient code.
+For more information see the online book `Supporting Python 3 <http://python3porting.com/toc.html>`_ by Lennart Regebro.
+
+.. _futurize: http://python-future.org/futurize.html
+
+.. _style-guide-py-pitfalls-mutables:
+
+A mutable object MUST NOT be used as a keyword argument default
+---------------------------------------------------------------
+
+Never use a mutable object as default value for a keyword argument in a function or method.
+
+When used a mutable is used as a default keyword argument, the default *can* change from one call to another leading to unexpected behavior.
+This issue can be avoided by only using immutable types as default.
+
+For example, rather than provide a default empty list:
+
+.. code-block:: py
+
+   def proclist(alist=[]):
+       pass
+
+this function should create a new list in its internal scope:
+
+.. code-block:: py
+
+   def proclist(alist=None):
+       if alist is None:
+           alist = []
+
+.. _style-guide-py-star-args:
+
+In function calls ``*`` SHOULD be used instead of ``apply``
+-----------------------------------------------------------
+
+In old versions of Python, to call a function with an argument list and/or keyword dictionary you had to write ``apply(func, args, keyargs)``.
+Now you can write ``func(*args, keyargs)``, which is faster and clearer.
+
+.. _style-guide-py-generators:
+
+Generators SHOULD be used to iterate overlarge data sets efficiently
+--------------------------------------------------------------------
+
+Use iterators, generators (classes that act like iterators) and generator expressions (expressions that act like iterators) to iterate over large data sets efficiently.
+
+.. _style-guide-py-context-managers:
+
+Context managers (``with``) SHOULD be used for resource allocation
+------------------------------------------------------------------
+
+Use the ``with`` statement to simplify resource allocation.
+
+For example to be sure a file will be closed when you are done with it: 
+  
+.. code-block:: py
+
+   with open('/etc/passwd', 'r') as f:
+       for line in f:
+           pass
+
+.. _style-guide-py-exception-handling-syntax:
+
+Python 2.5 improved Exception Handling SHOULD be used
+-----------------------------------------------------
+
+To catch all errors but let :py:exc:`~exceptions.SystemExit` and :py:exc:`~exceptions.KeyboardInterrupt` through, use:
+
+.. code-block:: py
+
+   except Exception, e:
+       pass
+
+The exception hierarchy in Python 2.5 was improved, eliminating the need to use this: 
+
+.. code-block:: py
+
+   except (SystemExit, KeyboardInterrupt):
+       raise
+       except Exception, e:
+           pass
+
+.. _style-guide-py-subprocess:
+
+The ``subprocess`` module SHOULD be used to spawn processes
+-----------------------------------------------------------
+
+Use the :py:mod:`subprocess` module to spawn processes.
+This supersedes and unifies :py:func:`os.system`, ``os.spawn``, :py:func:`os.popen`, etc..
+New in Python 2.3.
+
+.. _style-guide-py-lambda:
+
+``lambda`` SHOULD NOT be used
+-----------------------------
+
+Avoid the use of ``lambda``.
+You can almost always write clearer code by using a named function or using the :py:mod:`functools` module to wrap a function.
+
+.. _style-guide-py-set:
+
+The ``set`` type SHOULD be used for unordered collections
+---------------------------------------------------------
+
+Use the :py:class:`set` type for unordered collections of objects.
+New in Python 2.4 (though available via the ``Set`` module in Python 2.3).
+
+.. _style-guide-py-argparse:
+
+The ``argparse`` module SHOULD be used for command-line scripts 
+---------------------------------------------------------------
+
+Use the :py:mod:`argparse` module for command-line scripts.
+
+Command line tasks for pipelines should use :lclass:`lsst.pipe.base.ArgumentParser` instead.
+
+.. _style-guide-py-future-division:
+
+Use ``from __future__ import division``
+---------------------------------------
+
+This means ``/`` is floating-point division and ``//`` is truncated integer division, regardless of the type of numbers being divided.
+This gives more predictable behavior than the old operators, avoiding a common source of obscure bugs.
+It also makes intent of the code more obvious.
+
+.. _style-guide-py-future-absolute-import:
+
+Use ``from __future__ import absolute_import``
+----------------------------------------------
+
+In addition, import local modules using relative imports (e.g. ``from . import foo`` or ``from .foo import bar``).
+This results in clearer code and avoids shadowing global modules with local modules.
+
+.. _style-guide-py-future-itervalues:
+
+Use ``itervalues()`` and ``iteritems()`` instead of ``values()`` and ``items()``
+--------------------------------------------------------------------------------
+
+For iterating over dictionary values and items use the above idiom unless you truly need a list.
+This generates more efficient code today and helps futurize_ generate more efficient code in the future.
+For more information see http://python-future.org/compatible_idioms.html#iterating-through-dict-keys-values-items.
+
+.. _style-guide-py-dict-keys:
+
+Avoid ``dict.keys()`` and ``dict.iterkeys()``
+---------------------------------------------
+
+For iterating over keys, iterate over the dictionary itself, e.g.:
+
+.. code-block:: py
+
+   for x in mydict:
+       pass
+   
+To test for inclusion use ``in``:
+
+.. code-block:: py
+
+    if key in myDict:
+        pass
+    
+This is preferred over ``keys()`` and ``iterkeys()`` and avoids the issues mentioned in the previous item.
+
+.. _style-guide-py-open:
+
+Replace ``file`` with ``open``
+------------------------------
+
+This is preferred and ``file`` is gone in Python 3.
+
+.. _style-guide-py-exception-as:
+
+Use ``as`` when catching an exception
+-------------------------------------
+
+For example, use ``except Exception as e`` or ``except (LookupError, TypeError) as e``.
+The new syntax is clearer, especially when catching multiple exception classes, and the old syntax does not work in Python 3.
+
+.. note:: Conflicts with :ref:`style-guide-py-exception-handling-syntax`?
+
+.. _style-guide-py-print-function:
+
+Use from ``__future__ import print_function``
+---------------------------------------------
+
+Minor, but provides forward compatibility.
+This will affect very little code since we rarely use print.
+
+.. _style-guide-py-next:
+
+Use ``next(myIter)`` instead of ``myIter.next()``
+-------------------------------------------------
+
+The special method ``next`` has been renamed to ``__next__`` in Python 3.

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -586,31 +586,10 @@ This is preferred, and the special method ``next`` has been renamed to ``__next_
 
 .. _style-guide-py-layout:
 
-11. Layout
+10. Layout
 ==========
 
-.. _style-guide-py-11-1:
-
-Basic indentation MUST be 4 spaces
-----------------------------------
-
-Use 4 spaces per indentation level.
-
-This width provides a good balance between readability and excessive indentation.
-Using spaces instead of tabs assures that the code may be edited with all common editors and displayed with all common displays without special configuration.
-
-For an old code package that you don't wish to alter too far, you may use its existing indentation method with one exception, no tabs.
-
-.. _style-guide-py-11-2:
-
-Use of special character TAB is PROHIBITED
-------------------------------------------
-
-Existing code that mixes tabs and spaces must be converted to use 4 spaces per indentation level.
-
-To check a file you may invoke the Python command line interpreter with the ``-t/-tt`` option, it issues warnings/errors about code that illegally mixes tabs and spaces.
-
-.. _style-guide-py-11-3:
+.. _style-guide-py-line-length:
 
 Line Length MUST be less than or equal to 110 columns
 -----------------------------------------------------
@@ -618,7 +597,9 @@ Line Length MUST be less than or equal to 110 columns
 Limit all lines to a maximum of 110 characters.
 This conforms to the :doc:`cpp_style_guide` (see :ref:`4-6 <style-guide-cpp-4-6>`).
 
-.. _style-guide-py-11-4:
+This differs from the `PEP 8 recommendation of 79 characters <https://www.python.org/dev/peps/pep-0008/#id19>`_.
+
+.. _style-guide-py-implied-continuation:
 
 Python's implied continuation inside parens, brackets and braces SHOULD be used for wrapped lines
 -------------------------------------------------------------------------------------------------
@@ -644,51 +625,14 @@ Make sure to indent the continued line appropriately. Some examples:
             Blob.__init__(self, width, height,
                           color, emphasis, highlight)
 
-.. _style-guide-py-11-5:
+.. _style-guide-py-docstring-blank-lines:
 
-Blank Lines SHOULD be used to enhance readability
--------------------------------------------------
+Blank lines SHOULD NOT be added before or after a docstring
+-----------------------------------------------------------
 
-Use blank lines to make your code readable.
-The following are recommendations:
+Do not use a blank line on either side of a docstring.
 
-- Separate top-level function and class definitions with two blank lines.
-
-- Separate method definitions inside a class by a single blank line.
-
-- Do not use a blank line on either side of a doc string.
-
-- Use blank lines in functions, sparingly, to indicate logical sections.
-
-- Extra blank lines may be used (sparingly) to separate groups of related functions.
-
-- Blank lines may be omitted between a bunch of related one-liners (e.g. a set of dummy implementations).
-
-.. _style-guide-py-11-6:
-
-A package SHOULD be imported on one line
-----------------------------------------
-
-Each package should be imported on one line.
-For example, this is preferred: 
-
-.. code-block:: py
-
-   import os
-   import sys
-   from subprocess import Popen, PIPE
-
-Whereas this is not: 
-
-.. code-block:: py
-
-    # two packages imported on one line
-    import sys, os
-    # one package imported on two lines
-    from subprocess import Popen
-    from subprocess import PIPE
-
-.. _style-guide-py-11-7:
+.. _style-guide-py-cpp-consistency:
 
 Consistency with the DM C++ Coding Guide namespaces SHOULD be followed
 ----------------------------------------------------------------------
@@ -701,7 +645,7 @@ Consistency with the LSST C++ Coding Standards namespaces exists.
 
 - ``import lsst.foo.bar as fooBar`` is analogous to ``namespace fooBar = lsst::foo::bar``
 
-**Disallowed** in both Coding Standards (except in __init__.py library initialization context):
+**Disallowed** in both Coding Standards (except in :file:`__init__.py` library initialization context):
 
 - ``from lsst.foo.bar import *`` is analogous to ``using namespace lsst::foo::bar``
 

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -40,6 +40,8 @@ The separate `pep8-naming`_ plugin validates names according to the DM Python co
 .. _flake8: https://flake8.readthedocs.io
 .. _pep8-naming: http://pypi.python.org/pypi/pep8-naming
 
+.. _style-guide-py-flake8-install:
+
 Flake8 installation
 ^^^^^^^^^^^^^^^^^^^
 
@@ -50,19 +52,26 @@ Linters are installable with :command:`pip`:
    pip install flake8
    pip install pep8-naming
 
+.. _style-guide-py-flake8-invoke:
+
 Flake8 command line invocation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: bash
 
-   flake8 --ignore=E133,E226,E228,N802,N803 --max-line-length=110 {{python_dir}}
+   flake8 --ignore=E133,E226,E228,N802,N803 --max-line-length=110 .
 
-where ``{{python_dir}}`` is a directory with Python source files.
+This command lints all Python files in the current directory.
+Alternatively, individual files can be specified in place of ``.``.
+
+The ignored error codes are :ref:`explained below <style-guide-py-ignored-errors>`.
+
+.. _style-guide-py-flake8-config:
 
 Flake8 configuration files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-LSST DM Packages may also include a :file:`setup.cfg` file with `PEP 8`_ exceptions:
+LSST DM Packages may also include a :file:`setup.cfg` file with :pep:`8` exceptions:
 
 .. code-block:: ini
 
@@ -71,6 +80,8 @@ LSST DM Packages may also include a :file:`setup.cfg` file with `PEP 8`_ excepti
 	ignore = E133, E226, E228, E251, N802, N803
 
 :command:`flake8` can be invoked without arguments when this configuration is present.
+
+.. _style-guide-py-ignored-errors:
 
 Summary of PEP 8 exceptions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -134,10 +145,12 @@ Many PEP 8 issues in existing code can be fixed with `autopep8`_:
 
 .. code-block:: bash
 
-   autopep8 {{python_dir}} --in-place --recursive \
-       --ignore E133,E226,E228,N802,N803 --ma-line-length 110
+   autopep8 . --in-place --recursive \
+       --ignore E133,E226,E228,N802,N803 --max-line-length 110
 
-where ``{{python_dir}}`` is a directory with Python source files.
+The ``.`` specifies the current directory.
+Together with ``--recursive``, the full tree of Python files will be processed by :command:`autopep8`.
+Alternatively, a single file can be specified in place of ``.``.
 
 :command:`autopep8` changes must always be validated before committing.
 

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -296,34 +296,6 @@ Within a module, follow the order:
 
 .. note:: Delete mention of test suites?
 
-.. _style-guide-py-string-handling:
-
-5. String Handling
-==================
-
-.. _style-guide-py-string-5-1:
-
-String methods SHOULD be used instead of the string module
-----------------------------------------------------------
-
-Use `string methods <https://docs.python.org/2/library/stdtypes.html#string-methods>`_ instead of the :py:mod:`string` module.
-String methods are always much faster and share the same API with unicode strings.
-
-.. _style-guide-py-string-5-2:
-
-``.startswith()`` and ``.endswith()`` SHOULD be used to check for prefixes or suffixes
---------------------------------------------------------------------------------------
-
-Use :py:meth:`str.startswith()` and :py:meth:`str.endswith()` instead of string slicing to check for prefixes or suffixes; they are cleaner and less error prone.
-
-.. _style-guide-py-string-5-3:
-
-String literals SHOULD NOT rely on trailing whitespace
-------------------------------------------------------
-
-Don't write string literals that rely on significant trailing whitespace.
-Such trailing whitespace is visually indistinguishable and some editors (or more recently, :file:`reindent.py`) will trim them.
-
 .. _style-guide-py-comparisons:
 
 6. Comparisons

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -783,56 +783,22 @@ Paragraphs inside a block comment are separated by a line containing a single ``
 
 .. _style-guide-py-docstrings:
 
-14. Documentation Strings
-=========================
+13. Documentation Strings (docstrings)
+======================================
 
-Read the `DM Documentation Standards <https://dev.lsstcorp.org/trac/wiki/DocumentationStandards>`_ for the definitive formatting guidelines for DM python source files.
+Use **Numpydoc** to format the content of all docstrings.
+The page :doc:`../docs/py_docs` authoritatively describes this format.
+It's guide should be treated as an extension of this Python style guide.
 
-Read :pep:`257` for the pythonic discussion of docstrings.
-This is your main resource for information on writing doc strings.
-Here are a few minor points and emendations:
+See also the :doc:`../docs/rst_styleguide` and the :ref:`rst-formatting-guidelines` section in particular for guidelines on reStructuredText in general.
 
-.. _style-guide-py-14-1:
+.. _style-guide-py-docstring-public-api:
 
 Docstrings SHOULD be written for all public modules, functions, classes, and methods
 ------------------------------------------------------------------------------------
 
 Write docstrings for all public modules, functions, classes, and methods.
+See :doc:`../docs/py_docs`.
 
 Docstrings are not necessary for non-public methods, but you should have a comment that describes what the method does.
 This comment should appear after the ``def`` line.
-
-.. _style-guide-py-14-2:
-
-Docstrings SHOULD start with a 1-line imperative summary ending in a period
----------------------------------------------------------------------------
-
-Start the doc string with a one-line summary, a phrase ending in a period.
-Prescribe the function or method's effect as a command ("Do this", "Return that"), not as a description; e.g. don't write "Returns the pathname ...".
-
-.. _style-guide-py-14-3:
-
-Docstrings for functions, classes, and methods SHOULD include argument descriptions, return value, error conditions
--------------------------------------------------------------------------------------------------------------------
-
-After the docstring's summary line, if more information is wanted (as it usually is), include it after a blank line.
-This usually should include a description of the arguments, return value and important error conditions.
-
-If you mention arguments or other variables, always use their correct case.
-
-Docstrings should not be preceded or followed by a blank line.
-
-.. _style-guide-py-14-4:
-
-Docstrings SHOULD be begin with ``"""`` and terminate with ``"""`` on its own line
-----------------------------------------------------------------------------------
-
-Delimit doc strings with ``"""`` (three double quotes). You may use ``u"""`` for unicode but it is usually preferable to stick to ASCII.
-The terminating """ should be on its own line, even for one-line doc strings (this is a minor departure from :pep:`257`).
-
-.. code-block:: py
-
-   """Return a foobang
-    
-   Optional plotz says to frobnicate the bizbaz first.
-   """

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -2,7 +2,8 @@
 DM Python Style Guide
 #####################
 
-This is the version 5.0 of the DM Python Coding Standard.
+This is the version 6.0 of the DM Python Coding Standard.
+The :doc:`intro` provides the overarching Coding Standards policy applicable to all DM code.
 
 Changes to this document must be approved by the System Architect (`RFC-24 <https://jira.lsstcorp.org/browse/RFC-24>`_).
 To request changes to these standards, please file an :ref:`RFC <decision-making-rfc>`.
@@ -12,16 +13,133 @@ To request changes to these standards, please file an :ref:`RFC <decision-making
 
 .. _style-guide-py-intro:
 
-1. Introduction
-===============
+1. PEP 8 is the Baseline Coding Style
+=====================================
 
-This document gives coding conventions for DM Python code.
-It is a slightly modified version of `Python PEP 8: Style Guide for Python Code <http://www.python.org/dev/peps/pep-0008/>`_ by Guido van Rossum and Barry Warsaw.
-The section on :ref:`Naming Conventions <style-guide-py-naming>` was extracted from `Python Style Guide for Babar <http://www-spires.slac.stanford.edu/BFROOT/www/Computing/Programming/Python/PythonStyleGuide.html>`_ (account required) which is also based on the Python :pep:`8`.
-This document includes changes for consistency with the :doc:`cpp_style_guide` plus some additions and a few changes based the author's Python and C++ experiences. 
-The :doc:`intro` provides the overarching Coding Standards policy applicable to all DM code.
+Data Management's Python coding style is based the `PEP 8 Style Guide for Python Code <https://www.python.org/dev/peps/pep-0008/>`_ with modifications specified in this document.
+
+`PEP 8`_ is used throughout the Python community, and should feel familiar to Python developers.
+DM's deviations to `PEP 8`_ are motivated by consistency with the :doc:`cpp_style_guide`.
+Additional guidelines are included in this document to address specific requirements of the Data Management System.
 
 .. _PEP 8: http://www.python.org/dev/peps/pep-0008/
+
+.. _style-guide-py-flake8:
+
+Code MAY be validated with flake8
+---------------------------------
+
+The flake8_ tool may be used to validate Python source code against the portion of PEP 8 adopted by Data Management.
+In addition, flake8_ statically checks Python for code errors.
+The separate `pep8-naming`_ plugin validates names according to the DM Python coding style.
+
+.. note::
+   
+   Flake8 only validates code against PEP 8 specifications, but does not check the full coding standard listed here.
+
+.. _flake8: https://flake8.readthedocs.io
+.. _pep8-naming: http://pypi.python.org/pypi/pep8-naming
+
+Flake8 installation
+^^^^^^^^^^^^^^^^^^^
+
+Linters are installable with :command:`pip`:
+
+.. code-block:: bash
+
+   pip install flake8
+   pip install pep8-naming
+
+Flake8 command line invocation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   flake8 --ignore=E133,E226,E228,N802,N803 --max-line-length=110 {{python_dir}}
+
+where ``{{python_dir}}`` is a directory with Python source files.
+
+Flake8 configuration files
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+LSST DM Packages may also include a :file:`setup.cfg` file with `PEP 8`_ exceptions:
+
+.. code-block:: ini
+
+	[flake8]
+	max-line-length = 110
+	ignore = E133, E226, E228, E251, N802, N803
+
+:command:`flake8` can be invoked without arguments when this configuration is present.
+
+Summary of PEP 8 exceptions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+These error codes can be **ignored** by flake8_ when checking DM code against PEP 8 specifications:
+
+E133
+   Closing bracket is missing indentation.
+
+E226
+   Missing whitespace around arithmetic operator.
+
+E228
+   Missing whitespace around bitwise or shift operator.
+
+E251
+   Unexpected spaces around keyword / parameter equals.
+
+N802
+   Function name should be lowercase.
+
+N803
+   Argument name should be lowercase.
+
+.. _style-guide-py-noqa:
+
+Lines that intentionally deviate from DM's PEP 8 MUST include a ``noqa`` comment
+--------------------------------------------------------------------------------
+
+Lines of code may intentionally deviate from our application of PEP 8 (see above) because of limitations in flake8_.
+In such cases, authors must append a ``# noqa`` comment to the line that includes the specific error code being ignored.
+`See the flake8 documentation for details <https://flake8.readthedocs.io/en/latest/user/ignoring-errors.html#in-line-ignoring-errors>`__ .
+This prevents the line from triggering false flake8_ warnings to other developers, while also linting unexpected errors.
+
+For example, to import a module without using it (to build a namespace, as in a :file:`__init__.py`):
+
+.. code-block:: py
+
+   from .module import AClass  # noqa: F401
+
+.. seealso::
+
+   - `flake8 error codes <https://flake8.readthedocs.io/en/latest/user/error-codes.html>`_
+   - `pycodestyle error codes <https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes>`_
+   - `pep8-naming error codes <https://github.com/PyCQA/pep8-naming#plugin-for-flake8>`_
+
+.. _style-guide-py-autopep8:
+
+autopep8 MAY be used to fix PEP 8 compliance
+--------------------------------------------
+
+Many PEP 8 issues in existing code can be fixed with `autopep8`_:
+
+.. code-block:: bash
+
+   autopep8 {{python_dir}} --in-place --recursive \
+       --ignore E133,E226,E228,N802,N803 --ma-line-length 110
+
+where ``{{python_dir}}`` is a directory with Python source files.
+
+:command:`autopep8` changes must always be validated before committing.
+
+Style changes must be encapsulated in a distinct commit (see :ref:`git-commit-organization-logical-units` in :doc:`Workflow document <../processes/workflow>`).
+
+.. note::
+
+   :command:`autopep8` only fixes PEP 8 issues and does not address other guildelines listed here.
+
+.. _autopep8: https://pypi.python.org/pypi/autopep8
 
 .. _style-guide-py-naming:
 

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -24,6 +24,43 @@ Data Management's Python coding style is based the `PEP 8 Style Guide for Python
 DM's deviations from :pep:`8` are primarily motivated by consistency with the :doc:`cpp_style_guide`.
 Additional guidelines are included in this document to address specific requirements of the Data Management System.
 
+.. _style-guide-py-ignored-errors:
+
+Exceptions to PEP 8
+-------------------
+
+The following table summarizes all :pep:`8` guidelines are **not followed** by the DM Python Style Guide.
+These exceptions are phrased as error codes that may be ignored by the flake8_ linter (see :ref:`style-guide-py-flake8`).
+
+E133
+   Closing bracket is missing indentation.
+   This `pycodestyle error`_ (via flake8_) is not part of :pep:`8`.
+
+E226
+   Missing whitespace around arithmetic operator.
+   See :ref:`style-guide-py-operator-whitespace`.
+
+E228
+   Missing whitespace around bitwise or shift operator.
+   See :ref:`style-guide-py-operator-whitespace`.
+
+E251
+   Unexpected spaces around keyword / parameter equals.
+   See :ref:`style-guide-py-multiline-assignment-whitespace`.
+
+N802
+   Function name should be lowercase.
+   See :ref:`style-guide-py-naming`.
+
+N803
+   Argument name should be lowercase.
+   See :ref:`style-guide-py-naming`.
+
+Maximum line length
+   See :ref:`style-guide-py-line-length`.
+
+.. _pycodestyle error: http://pep8.readthedocs.io/en/latest/intro.html#error-codes
+
 .. _style-guide-py-flake8:
 
 Code MAY be validated with flake8
@@ -35,7 +72,8 @@ The separate `pep8-naming`_ plugin validates names according to the DM Python co
 
 .. note::
    
-   Flake8 only validates code against PEP 8 specifications, but does not check the full coding standard listed here.
+   Flake8 only validates code against PEP 8 specifications.
+   This style guide includes additional guidelines *are not* automatically linted.
 
 .. _flake8: https://flake8.readthedocs.io
 .. _pep8-naming: http://pypi.python.org/pypi/pep8-naming
@@ -81,38 +119,6 @@ LSST DM Packages may also include a :file:`setup.cfg` file with :pep:`8` excepti
 
 :command:`flake8` can be invoked without arguments when this configuration is present.
 
-.. _style-guide-py-ignored-errors:
-
-Summary of PEP 8 exceptions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-These error codes can be **ignored** by flake8_ when checking DM code against :pep:`8` specifications:
-
-E133
-   Closing bracket is missing indentation.
-   This `pycodestyle error`_ (via flake8_) is not part of :pep:`8`.
-
-E226
-   Missing whitespace around arithmetic operator.
-   See :ref:`style-guide-py-operator-whitespace`.
-
-E228
-   Missing whitespace around bitwise or shift operator.
-   See :ref:`style-guide-py-operator-whitespace`.
-
-E251
-   Unexpected spaces around keyword / parameter equals.
-   See :ref:`style-guide-py-multiline-assignment-whitespace`.
-
-N802
-   Function name should be lowercase.
-   See :ref:`style-guide-py-naming`.
-
-N803
-   Argument name should be lowercase.
-   See :ref:`style-guide-py-naming`.
-
-.. _pycodestyle error: http://pep8.readthedocs.io/en/latest/intro.html#error-codes
 
 .. _style-guide-py-noqa:
 
@@ -158,7 +164,7 @@ Style changes must be encapsulated in a distinct commit (see :ref:`git-commit-or
 
 .. note::
 
-   :command:`autopep8` only fixes PEP 8 issues and does not address other guildelines listed here.
+   :command:`autopep8` only fixes PEP 8 issues and does not address other guidelines listed here.
 
 .. _autopep8: https://pypi.python.org/pypi/autopep8
 

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -386,7 +386,7 @@ Now you can write ``func(*args, keyargs)``, which is faster and clearer.
 
 .. _style-guide-py-recommendations:
 
-8. Programming Recommendations
+7. Programming Recommendations
 ==============================
 
 Try to make your Python code idiomatic (*pythonic*).
@@ -408,7 +408,7 @@ Consider the following, slightly adapted from Tim Peters' `The Zen of Python <ht
 | If the implementation is hard to explain, it's a bad idea. 
 | If the implementation is easy to explain, it may be a good idea.
 
-.. _style-guide-py-8-1:
+.. _style-guide-py-idiomatic-python:
 
 Idiomatic modern Python SHOULD be used
 --------------------------------------
@@ -433,7 +433,7 @@ For example:
 The LSST environment currently supports Python 2.7.x.
 Do not use features that are not available in these versions of Python.
 
-.. _style-guide-py-8-2:
+.. _style-guide-py-exception-handling-syntax:
 
 Python 2.5 improved Exception Handling SHOULD be used
 -----------------------------------------------------
@@ -453,13 +453,6 @@ The exception hierarchy in Python 2.5 was improved, eliminating the need to use 
        raise
        except Exception, e:
            pass
-
-.. _style-guide-py-8-3:
-
-``raise ValueError('message')`` SHOULD be used instead of the deprecated form
------------------------------------------------------------------------------
-
-When raising an exception, use ``raise ValueError('message')`` instead of the older, deprecated form ``raise ValueError, 'message'``.
 
 .. _style-guide-py-suggested-modules:
 

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -298,19 +298,19 @@ Within a module, follow the order:
 
 .. _style-guide-py-comparisons:
 
-6. Comparisons
+5. Comparisons
 ==============
 
-.. _style-guide-py-6-1:
+.. _style-guide-py-comp-is:
 
 ``is`` and ``is not`` SHOULD only be used if determining if two variables point to same object
 ----------------------------------------------------------------------------------------------
 
-Avoid comparing with ``is`` and ``is not`` unless you really mean it.
-Use ``is`` or ``is not`` only for the very rare case that you need to know that two variables point to the exact same object.
-Usually you only care whether two objects have the same value, in which case use ``==`` or ``!=``.
+Use ``is`` or ``is not`` only for the case that you need to know that two variables point to the exact same object.
 
-.. _style-guide-py-6-2:
+To test equality in *value*, use ``==`` or ``!=`` instead.
+
+.. _style-guide-py-comp-none:
 
 ``is`` and ``is not`` SHOULD be used when comparing to ``None``
 ---------------------------------------------------------------
@@ -320,7 +320,7 @@ There are two reasons:
 1. ``is None`` works with NumPy arrays, whereas ``== None`` does not;
 2. ``is None`` is idiomatic.
 
-This is also consistent with :pep:`8` which states:
+This is also consistent with :pep:`8`, which `states <https://www.python.org/dev/peps/pep-0008/#id49>`__:
 
    Comparisons to singletons like ``None`` should always be done with ``is`` or ``is not``, never the equality operators.
 
@@ -346,42 +346,10 @@ No:
    if not len(seq):
        pass
 
-.. _style-guide-py-6-3:
-
-A conditional test of a boolean value SHOULD not explicitly test against ``True`` or ``False``
-----------------------------------------------------------------------------------------------
-
-Don't compare boolean values to ``True`` or ``False`` using ``==`` (unless it matters, e.g. for tri-state logic).
-
-Yes:
-
-.. code-block:: py
-
-   if greeting:
-
-No:
-
-.. code-block:: py
-
-   if greeting == True:
-       pass
-
-   if greeting is True:
-       pass
-
 .. _style-guide-py-pitfalls:
 
 7. Programming Pitfalls
 =======================
-
-.. _style-guide-py-7-1:
-
-``if x`` SHOULD NOT be used when you mean ``if x != None``
-----------------------------------------------------------
-
-Beware of writing ``if x`` when you mean ``if x != None``.
-This often comes up when testing whether a variable or argument that defaults to ``None`` was set to some other value.
-The other value might have a type (such as a container) that could be ``False`` in a boolean context!
 
 .. _style-guide-py-7-2:
 

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -456,10 +456,10 @@ The exception hierarchy in Python 2.5 was improved, eliminating the need to use 
 
 .. _style-guide-py-suggested-modules:
 
-9. Suggested Modules
+8. Suggested Modules
 ====================
 
-.. _style-guide-py-9-1:
+.. _style-guide-py-subprocess:
 
 The ``subprocess`` module SHOULD be used to spawn processes
 -----------------------------------------------------------
@@ -468,7 +468,7 @@ Use the :py:mod:`subprocess` module to spawn processes.
 This supersedes and unifies :py:func:`os.system`, ``os.spawn``, :py:func:`os.popen`, etc..
 New in Python 2.3.
 
-.. _style-guide-py-9-2:
+.. _style-guide-py-lambda:
 
 ``lambda`` SHOULD NOT be used
 -----------------------------
@@ -476,27 +476,22 @@ New in Python 2.3.
 Avoid the use of ``lambda``.
 You can almost always write clearer code by using a named function or using the :py:mod:`functools` module to wrap a function.
 
-.. _style-guide-py-9-3:
+.. _style-guide-py-set:
 
 The ``set`` type SHOULD be used for unordered collections
 ---------------------------------------------------------
 
-Use the :py:class`set` type for unordered collections of objects.
+Use the :py:class:`set` type for unordered collections of objects.
 New in Python 2.4 (though available via the ``Set`` module in Python 2.3).
 
-.. _style-guide-py-9-4:
+.. _style-guide-py-argparse:
 
 The ``argparse`` module SHOULD be used for command-line scripts 
 ---------------------------------------------------------------
 
 Use the :py:mod:`argparse` module for command-line scripts.
 
-.. _style-guide-py-9-5:
-
-Pychecker or pylint SHOULD be used to check your code
------------------------------------------------------
-
-Check your code with `pychecker <http://pychecker.sourceforge.net>`_ or `pylint <http://www.pylint.org>`_.
+Command line tasks for pipelines should use :lclass:`lsst.pipe.base.ArgumentParser` instead.
 
 .. _style-guide-py-py3:
 

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -297,7 +297,7 @@ Never surround these binary arithmetic operators with whitespace:
 - division (``/``),
 - exponentiation (``**``),
 - floor division (``//``),
-- modulus (``%``).
+- modulus (``%``). Note that a single space **must always** surround ``%`` when used for string formatting.
 
 For example:
 
@@ -308,9 +308,10 @@ For example:
    x = x*2 - 1
    hypot2 = x*x + y*y
    c = (a + b)*(a - b)
+   print('Hello %s' % 'world!')
 
 This deviates from PEP 8, which `allows whitespace around these arithmetic operators if they appear alone <https://www.python.org/dev/peps/pep-0008/#id28>`__.
-Error codes: N226 and N228.
+Error codes: E226 and E228.
 
 .. _style-guide-py-multiline-assignment-whitespace:
 

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -146,16 +146,16 @@ Style changes must be encapsulated in a distinct commit (see :ref:`git-commit-or
 2. Naming Conventions
 =====================
 
+We follow `PEP 8ʼs naming conventions <https://www.python.org/dev/peps/pep-0008/#naming-conventions>`_, with exceptions listed here.
 The naming conventions for LSST Python and C++ source have been defined to be as similar as the respective languages allow.
-In general, class names are ``CamelCase`` with leading uppercase; all other names in the source are ``camelCase`` with leading lowercase, except for module variables used as module global constants---which should be ``UPPERCASE_WITH_UNDERSCORES``.
+
+In general:
+
+- class names are ``CamelCase`` with leading uppercase,
+- module variables used as module global constants are ``UPPERCASE_WITH_UNDERSCORES``,
+- all other names are ``camelCase`` with leading lowercase.
+
 Names may be decorated with leading and/or trailing underscores.
-
-.. _style-guide-py-2-1:
-
-User-defined names with double leading and trailing underscores MUST NOT be used
---------------------------------------------------------------------------------
-
-Names with double leading and trailing underscores are reserved by Python (e.g. ``__init__``, ``__name__``, ``__str__``).
 
 .. _style-guide-py-2-2:
 
@@ -166,115 +166,44 @@ Names which shadow a python built-in function may cause confusion for readers of
 Creating a more specific identifier is suggested to avoid collisions.
 In the case of *filter*, ``filterName`` may be appropriate; for *filter objects*, something like ``filterObj`` might be appropriate.
 
-.. _style-guide-py-2-3:
-
-Class names SHOULD use CamelCase with leading uppercase
--------------------------------------------------------
-
-Python class names should follow the same conventions as C++ class names---they should be ``CamelCase`` with leading uppercase.
-Note that exceptions are classes and thus follow the same convention.
-
-.. _style-guide-py-2-4:
-
-Exception names relating to errors SHOULD include the suffix Error
-------------------------------------------------------------------
-
-An error exception name SHOULD include the suffix ``Error``.
-
-.. _style-guide-py-2-5:
+.. _style-guide-py-naming-attributes:
 
 Class Attribute Names SHOULD be camelCase with leading lowercase
 ----------------------------------------------------------------
 
----
+`Opposes PEP 8 <https://www.python.org/dev/peps/pep-0008/#id45>`__.
 
-.. _style-guide-py-2-6:
+.. _style-guide-py-naming-functions:
 
 Module methods (free functions) SHOULD be camelCase with leading lowercase
 --------------------------------------------------------------------------
 
----
+`Opposes PEP 8 <https://www.python.org/dev/peps/pep-0008/#id45>`__.
 
-.. _style-guide-py-2-7:
-
-Module constants SHOULD be named in ``UPPERCASE_WITH_UNDERSCORES``
-------------------------------------------------------------------
-
-Modules should not normally expose their variables directly.
-The exception is for variables which are constants: they should be named in ``UPPERCASE_WITH_UNDERSCORES``.
-
-.. _style-guide-py-2-8:
+.. _style-guide-py-naming-class-modules:
 
 Modules which contain class definitions SHOULD be named after the class name
 ----------------------------------------------------------------------------
 
 Modules which contain class definitions should be named after the class name (one module per class).
 
-.. _style-guide-py-2-9:
+.. _style-guide-py-naming-ext-modules:
 
 When a Python module wraps a C/C++ extension module, the C/C++ module SHOULD be named <module>Lib
 -------------------------------------------------------------------------------------------------
 
 When an extension module written in C or C++ has an accompanying Python module that provides a higher level (e.g. more object oriented) interface, the C/C++ module should append ``Lib`` to the module's name (e.g. ``socketLib``).
 
-.. _style-guide-py-2-10:
-
-Single leading underscore SHOULD be used to indicate 'internal use'
--------------------------------------------------------------------
-
-Single leading underscore is a weak 'internal use' indicator for which Python does not mangle the name on use.
-This 'internal use' indicator is useful not only as a visual programming convention but also because ``from M import *`` does not import names starting with an underscore.
-
-.. _style-guide-py-2-11:
-
-Private Class Attribute Names SHOULD be prefixed with a double underscore
--------------------------------------------------------------------------
-
-To make an attribute private, prefix it with double underscore: ``__name``.
-Python mangles attribute names that start with ``__``, thus weakly enforcing privacy.
-
-If your class is intended to be subclassed, and you have attributes that you do not want subclasses to use, name them with double leading underscores and no trailing underscores.
-This invokes Python's name mangling algorithm, where the name of the class is mangled into the attribute name.
-This helps avoid attribute name collisions should subclasses inadvertently contain attributes with the same name.
-
-- Only the simple class name is used in the mangled name, so if a subclass chooses both the same class name and attribute name, you can still get name collisions.
-
-- Name mangling can make certain uses, such as debugging and ``getattr()``, less convenient. However the name mangling algorithm is well documented and easy to perform manually.
-
-- Not everyone likes name mangling. Try to balance the need to avoid accidental name clashes with potential use by advanced callers.
-
-.. _style-guide-py-2-12:
-
-Modules designed for use via ``from M import *`` SHOULD use the ``__all__`` mechanism
--------------------------------------------------------------------------------------
-
-Modules that are designed for use via ``from M import *`` should use the ``__all__`` mechanism to ensure only the globals comprising the public API are exported.
-Failure to use the ``__all__`` mechanism results in all names in the module's namespace, which do not begin with a single ``_``, being exported as global.
-
-.. _style-guide-py-2-13:
-
-``self`` MUST be used for the first argument to instance methods
-----------------------------------------------------------------
-
-Always use ``self`` for the first argument to instance methods.
-
-.. _style-guide-py-2-14:
-
-``cls`` MUST be used for the first argument to class methods
-------------------------------------------------------------
-
-Always use ``cls`` for the first argument to class methods.
-
-.. _style-guide-py-2-15:
+.. _style-guide-py-naming-ambiguous:
 
 Names l (lowercase: el), O (uppercase: oh), I (uppercase: eye) MUST be avoided
 ------------------------------------------------------------------------------
 
-Never use the characters
+Never use these characters as single character variable names:
 
 - ``l`` (lowercase letter el),
 - ``O`` (uppercase letter oh), or
-- ``I`` (uppercase letter eye) as single character variable names.
+- ``I`` (uppercase letter eye).
 
 In some fonts, these characters are indistinguishable from the numerals one and zero.
 When tempted to use ``l``, use ``L`` instead.

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -170,25 +170,48 @@ Python's implied continuation inside parens, brackets and braces SHOULD be used 
 -------------------------------------------------------------------------------------------------
 
 The preferred way of wrapping long lines is by using Python's implied line continuation inside parentheses, brackets and braces.
+
 If necessary, you can add an extra pair of parentheses around an expression, but sometimes using a backslash looks better.
-Make sure to indent the continued line appropriately. Some examples:
+In this example, continuation is naturally implied within the ``__init__`` method argument lists, while both ``\`` and parentheses-based continuations are used in the ``if`` statements.
 
 .. code-block:: py
 
-    class Rectangle(Blob):
-        """Documentation for Rectangle.
-        """
-        def __init__(self, width, height,
-                     color='black', emphasis=None, highlight=0):
-            if width == 0 and height == 0 and
-               color == 'red' and emphasis == 'strong' or
-               highlight > 100:
-                raise ValueError("sorry, you lose")
-            if width == 0 and height == 0 and (color == 'red' or
-                                               emphasis is None):
-                raise ValueError("I don't think so")
-            Blob.__init__(self, width, height,
-                          color, emphasis, highlight)
+   class Rectangle(Blob):
+       """Documentation for Rectangle.
+       """
+       def __init__(self, width, height,
+                    color='black', emphasis=None, highlight=0):
+   
+           # Discouraged: continuation with '\'
+           if width == 0 and height == 0 and \
+                  color == 'red' and emphasis == 'strong' or \
+                  highlight > 100:
+               raise ValueError("sorry, you lose")
+   
+           # Preferred: continuation with parentheses
+           if width == 0 and height == 0 and (color == 'red' or
+                                              emphasis is None):
+               raise ValueError("I don't think so")
+   
+           Blob.__init__(self, width, height,
+                         color, emphasis, highlight)
+
+Be aware that the continued line must be distinguished from the following lines through indentation.
+For example, this will generate an E129 error:
+
+.. code-block:: py
+
+   if (width == 0 and
+       height == 0):
+       pass
+
+Instead, the continued line should be indented:
+
+.. code-block:: py
+
+   if (width == 0 and
+           height == 0):
+       pass
 
 .. _style-guide-py-docstring-blank-lines:
 

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -619,21 +619,6 @@ this function should create a new list in its internal scope:
        if alist is None:
            alist = []
 
-.. _style-guide-py-star-args:
-
-In function calls ``*`` SHOULD be used instead of ``apply``
------------------------------------------------------------
-
-In old versions of Python, to call a function with an argument list and/or keyword dictionary you had to write ``apply(func, args, keyargs)``.
-Now you can write ``func(*args, keyargs)``, which is faster and clearer.
-
-.. _style-guide-py-generators:
-
-Generators SHOULD be used to iterate overlarge data sets efficiently
---------------------------------------------------------------------
-
-Use iterators, generators (classes that act like iterators) and generator expressions (expressions that act like iterators) to iterate over large data sets efficiently.
-
 .. _style-guide-py-context-managers:
 
 Context managers (``with``) SHOULD be used for resource allocation
@@ -649,26 +634,12 @@ For example to be sure a file will be closed when you are done with it:
        for line in f:
            pass
 
-.. _style-guide-py-exception-handling-syntax:
+.. _style-guide-py-open:
 
-Python 2.5 improved Exception Handling SHOULD be used
------------------------------------------------------
+Use ``open`` instead of ``file``
+--------------------------------
 
-To catch all errors but let :py:exc:`~exceptions.SystemExit` and :py:exc:`~exceptions.KeyboardInterrupt` through, use:
-
-.. code-block:: py
-
-   except Exception, e:
-       pass
-
-The exception hierarchy in Python 2.5 was improved, eliminating the need to use this: 
-
-.. code-block:: py
-
-   except (SystemExit, KeyboardInterrupt):
-       raise
-       except Exception, e:
-           pass
+``file`` is gone in Python 3.
 
 .. _style-guide-py-subprocess:
 
@@ -676,15 +647,13 @@ The ``subprocess`` module SHOULD be used to spawn processes
 -----------------------------------------------------------
 
 Use the :py:mod:`subprocess` module to spawn processes.
-This supersedes and unifies :py:func:`os.system`, ``os.spawn``, :py:func:`os.popen`, etc..
-New in Python 2.3.
 
 .. _style-guide-py-lambda:
 
 ``lambda`` SHOULD NOT be used
 -----------------------------
 
-Avoid the use of ``lambda``.
+Avoid the use of `lambda <https://docs.python.org/3/reference/expressions.html#lambda>`__.
 You can almost always write clearer code by using a named function or using the :py:mod:`functools` module to wrap a function.
 
 .. _style-guide-py-set:
@@ -693,7 +662,6 @@ The ``set`` type SHOULD be used for unordered collections
 ---------------------------------------------------------
 
 Use the :py:class:`set` type for unordered collections of objects.
-New in Python 2.4 (though available via the ``Set`` module in Python 2.3).
 
 .. _style-guide-py-argparse:
 
@@ -721,13 +689,29 @@ Use ``from __future__ import absolute_import``
 In addition, import local modules using relative imports (e.g. ``from . import foo`` or ``from .foo import bar``).
 This results in clearer code and avoids shadowing global modules with local modules.
 
+.. _style-guide-py-exception-as:
+
+Use ``as`` when catching an exception
+-------------------------------------
+
+For example, use ``except Exception as e`` or ``except (LookupError, TypeError) as e``.
+The new syntax is clearer, especially when catching multiple exception classes, and required in Python 3.
+
+.. _style-guide-py-generators:
+
+Iterators and generators SHOULD be used to iterate over large data sets efficiently
+-----------------------------------------------------------------------------------
+
+Use iterators, generators (classes that act like iterators) and generator expressions (expressions that act like iterators) to iterate over large data sets efficiently.
+
 .. _style-guide-py-future-itervalues:
 
 Use ``itervalues()`` and ``iteritems()`` instead of ``values()`` and ``items()``
 --------------------------------------------------------------------------------
 
 For iterating over dictionary values and items use the above idiom unless you truly need a list.
-This generates more efficient code today and helps futurize_ generate more efficient code in the future.
+
+This pattern does not apply to code that has already been ported to Python 3 with futurize_
 For more information see http://python-future.org/compatible_idioms.html#iterating-through-dict-keys-values-items.
 
 .. _style-guide-py-dict-keys:
@@ -751,30 +735,14 @@ To test for inclusion use ``in``:
     
 This is preferred over ``keys()`` and ``iterkeys()`` and avoids the issues mentioned in the previous item.
 
-.. _style-guide-py-open:
-
-Replace ``file`` with ``open``
-------------------------------
-
-This is preferred and ``file`` is gone in Python 3.
-
-.. _style-guide-py-exception-as:
-
-Use ``as`` when catching an exception
--------------------------------------
-
-For example, use ``except Exception as e`` or ``except (LookupError, TypeError) as e``.
-The new syntax is clearer, especially when catching multiple exception classes, and the old syntax does not work in Python 3.
-
-.. note:: Conflicts with :ref:`style-guide-py-exception-handling-syntax`?
-
-.. _style-guide-py-print-function:
+.. _style-guide-py-print:
 
 Use from ``__future__ import print_function``
 ---------------------------------------------
 
-Minor, but provides forward compatibility.
-This will affect very little code since we rarely use print.
+The :py:func:`print()` function is required in Python 3.
+
+In general, DM code should be use logging instead of ``print`` statements.
 
 .. _style-guide-py-next:
 
@@ -782,3 +750,4 @@ Use ``next(myIter)`` instead of ``myIter.next()``
 -------------------------------------------------
 
 The special method ``next`` has been renamed to ``__next__`` in Python 3.
+This allows iterators to be advanced with the :py:func:`next` built-in function in both Python 2.7 and Python 3.

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -651,60 +651,12 @@ Consistency with the LSST C++ Coding Standards namespaces exists.
 
 .. _style-guide-py-whitespace:
 
-12. Whitespace
+11. Whitespace
 ==============
 
-.. _style-guide-py-12-1:
+Follow the `PEP 8 whitespace style guidelines <https://www.python.org/dev/peps/pep-0008/#id26>`_, with the following adjustments.
 
-Extraneous Whitespace SHOULD be avoided
----------------------------------------
-
-Avoid extraneous whitespace in the following situations:
-
-- immediately inside parentheses, brackets or braces:
-
-  Yes: ``spam(ham[1], {eggs: 2})``
-
-  No: ``spam( ham[ 1 ], { eggs: 2 } )``
-
-- immediately before a comma, semicolon, or colon: 
-
-  Yes: ``if x == 4: print x, y; x, y = y, x``
-
-  No: ``if x == 4 : print x , y ; x , y = y , x``
-
-- immediately before the open parenthesis that starts the argument list of a function call:
-
-  Yes: ``spam(1)``
-
-  No:  ``spam (1)``
-
-- immediately before the open parenthesis that starts an indexing or slicing: 
-
-  Yes: ``dict['key'] = list[index]``
-
-  No:  ``dict ['key'] = list [index]``
-
-- More than one space around an assignment (or other) operator to align it with another.
-  Make an exception if alignment makes the data significantly clearer (e.g. complex lookup tables).
-
-  Thus: 
-
-  .. code-block:: py
-
-     x = 1
-     y = 2
-     long_variable = 3
-
-  Not this:
-
-  .. code-block:: py
-
-     x             = 1
-     y             = 2
-     long_variable = 3
-
-.. _style-guide-py-12-2:
+.. _style-guide-py-minimal-parens:
 
 The minimum number of parenthesis needed for correctness and readability SHOULD be used
 ---------------------------------------------------------------------------------------
@@ -721,7 +673,7 @@ Less readable:
 
    a = b((self.config.nSigmaToGrow*sigma) + 0.5)
  
-.. _style-guide-py-12-3:
+.. _style-guide-py-operator-whitespace:
 
 Binary operators SHOULD be surrounded by a single space except for [``*``, ``/``, ``**``, ``//``, ``%``\ ]
 ----------------------------------------------------------------------------------------------------------
@@ -746,8 +698,7 @@ Never surround these binary arithmetic operators with whitespace:
 - floor division (``//``),
 - modulus (``%``).
 
-The one exception is assigning values to multiple keyword arguments on a single line, where spaces around "=" obscure the separation between the separate arguments. 
-Thus this: 
+For example:
 
 .. code-block:: py
 
@@ -756,50 +707,44 @@ Thus this:
    x = x*2 - 1
    hypot2 = x*x + y*y
    c = (a + b)*(a - b)
+
+This deviates from PEP 8, which `allows whitespace around these arithmetic operators if they appear alone <https://www.python.org/dev/peps/pep-0008/#id28>`__.
+
+.. _style-guide-py-multiline-assignment-whitespace:
+
+Keyword assignment operators SHOULD be surrounded by a space when statements appear on multiple lines
+-----------------------------------------------------------------------------------------------------
+
+However, if keyword assignments occur on a single line, where should be no additional spaces.
+
+Thus this: 
+
+.. code-block:: py
+
+   # whitespace around multi-line assignment
    funcA(
        karg1 = value1,
        karg2 = value2,
        karg3 = value3,
    )
+
+   # no whitespace around single-line assigment
    funcB(x, y, z, karg1=value1, karg2=value2, karg3=value3)
 
 Not this: 
 
 .. code-block:: py
 
-   i=i+1
-   submitted +=1
-   x = x * 2 - 1
-   hypot2 = x * x + y * y
-   c = (a+b) * (a-b)
    funcA(
        karg1=value1,
        karg2=value2,
        karg3=value3,
    )
+
    aFunction(x, y, z, karg1 = value1, karg2 = value2, karg3 = value3)
+
+`Opposes PEP 8 <https://www.python.org/dev/peps/pep-0008/#id28>`__.
  
-.. _style-guide-py-12-4:
-
-Spaces MUST NOT be used around ``=`` for Default Parameter
-----------------------------------------------------------
-
-Don't use spaces around the ``=`` sign when used to indicate a default parameter value.
-
-Thus this:
-
-.. code-block:: py
-
-   def complex(real, imag=0.0):
-       pass
-
-but not this:
-
-.. code-block:: py
-
-   def complex(real, imag = 0.0):
-       pass
-
 .. _style-guide-py-comments:
 
 13. Comments

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -152,7 +152,7 @@ Many :pep:`8` issues in existing code can be fixed with `autopep8`_:
 .. code-block:: bash
 
    autopep8 . --in-place --recursive \
-       --ignore E133,E226,E228,N251,N802,N803 --max-line-length 110
+       --ignore E133,E226,E228,E251,N802,N803 --max-line-length 110
 
 The ``.`` specifies the current directory.
 Together with ``--recursive``, the full tree of Python files will be processed by :command:`autopep8`.
@@ -353,7 +353,7 @@ Not this:
    aFunction(x, y, z, karg1 = value1, karg2 = value2, karg3 = value3)
 
 `Opposes PEP 8 <https://www.python.org/dev/peps/pep-0008/#id28>`__.
-Error code: N251.
+Error code: E251.
 
 .. _style-guide-py-comments:
 

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -495,15 +495,17 @@ Command line tasks for pipelines should use :lclass:`lsst.pipe.base.ArgumentPars
 
 .. _style-guide-py-py3:
 
-10. Python 3 Idioms
-===================
+9. Python 3 Idioms
+==================
 
 It is possible to write much of the Python code in a way that will run well under both Python 2.7 and Python 3.x, without harming readability (and in some cases, improving it).
-There are other cases where code can be written in a way that helps the 2to3_ code converter produce more efficient code.
+There are other cases where code can be written in a way that helps the futurize_ code converter produce more efficient code.
 
-.. _2to3: https://docs.python.org/2/library/2to3.html
+For more information see http://python3porting.com/toc.html, among several useful references.
 
-.. _style-guide-py-10-1:
+.. _futurize: http://python-future.org/futurize.html
+
+.. _style-guide-py-future-division:
 
 Use ``from __future__ import division``
 ---------------------------------------
@@ -512,25 +514,24 @@ This means ``/`` is floating-point division and ``//`` is truncated integer divi
 This gives more predictable behavior than the old operators, avoiding a common source of obscure bugs.
 It also makes intent of the code more obvious.
 
-.. _style-guide-py-10-2:
+.. _style-guide-py-future-absolute-import:
 
 Use ``from __future__ import absolute_import``
 ----------------------------------------------
 
 In addition, import local modules using relative imports (e.g. ``from . import foo`` or ``from .foo import bar``).
 This results in clearer code and avoids shadowing global modules with local modules.
-It also makes 2to3_ conversion more reliable.
 
-.. _style-guide-py-10-3:
+.. _style-guide-py-future-itervalues:
 
 Use ``itervalues()`` and ``iteritems()`` instead of ``values()`` and ``items()``
 --------------------------------------------------------------------------------
 
 For iterating over dictionary values and items use the above idiom unless you truly need a list.
-This generates more efficient code today and helps 2to3_ generate more efficient code in the future.
-For more information see http://python3porting.com/preparing.html#optional-use-the-iterator-methods-on-dictionaries.
+This generates more efficient code today and helps futurize_ generate more efficient code in the future.
+For more information see http://python-future.org/compatible_idioms.html#iterating-through-dict-keys-values-items.
 
-.. _style-guide-py-10-4:
+.. _style-guide-py-dict-keys:
 
 Avoid ``dict.keys()`` and ``dict.iterkeys()``
 ---------------------------------------------
@@ -551,14 +552,14 @@ To test for inclusion use ``in``:
     
 This is preferred over ``keys()`` and ``iterkeys()`` and avoids the issues mentioned in the previous item.
 
-.. _style-guide-py-10-5:
+.. _style-guide-py-open:
 
 Replace ``file`` with ``open``
 ------------------------------
 
 This is preferred and ``file`` is gone in Python 3.
 
-.. _style-guide-py-10-6:
+.. _style-guide-py-exception-as:
 
 Use ``as`` when catching an exception
 -------------------------------------
@@ -566,7 +567,9 @@ Use ``as`` when catching an exception
 For example, use ``except Exception as e`` or ``except (LookupError, TypeError) as e``.
 The new syntax is clearer, especially when catching multiple exception classes, and the old syntax does not work in Python 3.
 
-.. _style-guide-py-10-7:
+.. note:: Conflicts with :ref:`style-guide-py-exception-handling-syntax`?
+
+.. _style-guide-py-print-function:
 
 Use from ``__future__ import print_function``
 ---------------------------------------------
@@ -574,14 +577,12 @@ Use from ``__future__ import print_function``
 Minor, but provides forward compatibility.
 This will affect very little code since we rarely use print.
 
-.. _style-guide-py-10-8:
+.. _style-guide-py-next:
 
 Use ``next(myIter)`` instead of ``myIter.next()``
 -------------------------------------------------
 
 This is preferred, and the special method ``next`` has been renamed to ``__next__`` in Python 3.
-
-For more information see  http://python3porting.com/toc.html, among several useful references.
 
 .. _style-guide-py-layout:
 

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -234,7 +234,7 @@ In that case, use properties to hide functional implementation behind simple dat
 
 - Note 3: Avoid using properties for computationally expensive operations; the attribute notation makes the caller believe that access is (relatively) cheap.
 
-.. _style-guide-py-3-1:
+.. _style-guide-py-super:
 
 ``super`` SHOULD NOT be used unless the author really understands the implications (e.g. in a well-understood multiple inheritance hierarchy).
 ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -348,64 +348,37 @@ No:
 
 .. _style-guide-py-pitfalls:
 
-7. Programming Pitfalls
+6. Programming Pitfalls
 =======================
 
-.. _style-guide-py-7-2:
+.. _style-guide-py-pitfalls-mutables:
 
-A mutable object MUST NOT be used as default in arg list
---------------------------------------------------------
+A mutable object MUST NOT be used as a keyword argument default
+---------------------------------------------------------------
 
-Never use a mutable object as default value in a function or method argument list.
-The problem is that the default value may itself change, leading to subtle bugs.
-This problem bites many new Python programmers, though usually only once.
-To avoid the problem use something like the following: 
+Never use a mutable object as default value for a keyword argument in a function or method.
 
-.. code-block:: py
+When used a mutable is used as a default keyword argument, the default *can* change from one call to another leading to unexpected behavior.
+This issue can be avoided by only using immutable types as default.
 
-   def proclist(alist=None):
-   if alist == None:
-   alist = []
-
-   # if you can tolerate a tuple; tuples are immutable
-   def proclist(alist=()):
-       pass
-
-Rather than the more obvious but dangerously wrong: 
+For example, rather than provide a default empty list:
 
 .. code-block:: py
 
    def proclist(alist=[]):
        pass
 
-.. _style-guide-py-7-3:
-
-Object type comparisons SHOULD always use ``isinstance()``
-----------------------------------------------------------
-
-Object type comparisons should always use :py:func:`isinstance()` instead of comparing types directly. 
-
-Yes:
+this function should create a new list in its internal scope:
 
 .. code-block:: py
 
-   if isinstance(obj, int):
-       pass
+   def proclist(alist=None):
+       if alist is None:
+           alist = []
 
-.. code-block:: py
+.. _style-guide-py-pitfalls-star-args:
 
-   if type(obj) is type(1):
-       pass
-
-When checking if an object is a string, keep in mind that it might be a unicode string too! Starting with Python 2.3, `str` and `unicode` have a common base class, `basestring`, so you can do: 
-
-.. code-block:: py
-
-   if ``isinstance(obj, basestring)``:
-
-.. _style-guide-py-7-4:
-
-In function calls ``*`` and SHOULD be used instead of ``apply``
+In function calls ``*`` SHOULD be used instead of ``apply``
 ---------------------------------------------------------------
 
 In old versions of Python, to call a function with an argument list and/or keyword dictionary you had to write ``apply(func, args, keyargs)``.

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -5,8 +5,10 @@ DM Python Style Guide
 This is the version 6.0 of the DM Python Coding Standard.
 The :doc:`intro` provides the overarching Coding Standards policy applicable to all DM code.
 
-Changes to this document must be approved by the System Architect (`RFC-24 <https://jira.lsstcorp.org/browse/RFC-24>`_).
-To request changes to these standards, please file an :ref:`RFC <decision-making-rfc>`.
+.. note::
+
+   Changes to this document must be approved by the System Architect (`RFC-24 <https://jira.lsstcorp.org/browse/RFC-24>`_).
+   To request changes to these standards, please file an :ref:`RFC <decision-making-rfc>`.
 
 .. contents::
    :depth: 4

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -20,18 +20,16 @@ The :doc:`intro` provides the overarching Coding Standards policy applicable to 
 
 Data Management's Python coding style is based the `PEP 8 Style Guide for Python Code <https://www.python.org/dev/peps/pep-0008/>`_ with modifications specified in this document.
 
-`PEP 8`_ is used throughout the Python community, and should feel familiar to Python developers.
-DM's deviations to `PEP 8`_ are motivated by consistency with the :doc:`cpp_style_guide`.
+:pep:`8` is used throughout the Python community and should feel familiar to Python developers.
+DM's deviations from :pep:`8` are primarily motivated by consistency with the :doc:`cpp_style_guide`.
 Additional guidelines are included in this document to address specific requirements of the Data Management System.
-
-.. _PEP 8: http://www.python.org/dev/peps/pep-0008/
 
 .. _style-guide-py-flake8:
 
 Code MAY be validated with flake8
 ---------------------------------
 
-The flake8_ tool may be used to validate Python source code against the portion of PEP 8 adopted by Data Management.
+The flake8_ tool may be used to validate Python source code against the portion of :pep:`8` adopted by Data Management.
 In addition, flake8_ statically checks Python for code errors.
 The separate `pep8-naming`_ plugin validates names according to the DM Python coding style.
 
@@ -143,7 +141,7 @@ For example, to import a module without using it (to build a namespace, as in a 
 autopep8 MAY be used to fix PEP 8 compliance
 --------------------------------------------
 
-Many PEP 8 issues in existing code can be fixed with `autopep8`_:
+Many :pep:`8` issues in existing code can be fixed with `autopep8`_:
 
 .. code-block:: bash
 
@@ -154,7 +152,7 @@ The ``.`` specifies the current directory.
 Together with ``--recursive``, the full tree of Python files will be processed by :command:`autopep8`.
 Alternatively, a single file can be specified in place of ``.``.
 
-:command:`autopep8` changes must always be validated before committing.
+:command:`autopep8`\ ʼs changes must always be validated before committing.
 
 Style changes must be encapsulated in a distinct commit (see :ref:`git-commit-organization-logical-units` in :doc:`Workflow document <../processes/workflow>`).
 
@@ -261,7 +259,7 @@ Follow the `PEP 8 whitespace style guidelines <https://www.python.org/dev/peps/p
 
 .. _style-guide-py-minimal-parens:
 
-The minimum number of parenthesis needed for correctness and readability SHOULD be used
+The minimum number of parentheses needed for correctness and readability SHOULD be used
 ---------------------------------------------------------------------------------------
 
 Yes:
@@ -499,7 +497,7 @@ The name of a test case should be descriptive without the need for a trailing nu
 ASCII Encoding MUST be used for new code
 ----------------------------------------
 
-Always use ASCII for new python code.
+Always use ASCII for new Python code.
 
 - **Do not** include a coding comment (as described in  :pep:`263`) for ASCII files.
 
@@ -530,7 +528,7 @@ Within a module, follow the order:
 8. Classes
 ==========
 
-.. seealso:: `Designing for Inheritance <https://www.python.org/dev/peps/pep-0008/#id47>`__ in :pep:`8` for naming conventions related to public and private class APIs.
+.. seealso:: `Designing for Inheritance <https://www.python.org/dev/peps/pep-0008/#id47>`__ in :pep:`8` describes naming conventions related to public and private class APIs.
 
 .. _style-guide-py-super:
 
@@ -539,16 +537,16 @@ Within a module, follow the order:
 
 Python provides :py:func:`super` so that each parent class' method is only called once.
 
-To use :py:func:`super`, all parent classes in the chain (also called the Method Resolution Order") need to use :py:func:`super` otherwise the chain gets interrupted. 
+To use :py:func:`super`, all parent classes in the chain (also called the Method Resolution Order) need to use :py:func:`super` otherwise the chain gets interrupted. 
 Other subtleties have been noted in `an article by James Knight <https://fuhm.net/super-harmful/>`__:
 
-- Never call super with anything but the exact arguments you received, unless you really know what you're doing.
-- When you use it on methods whose acceptable arguments can be altered on a subclass via addition of more optional arguments, always accept ``*args, **kw``, and call ``super`` like ``super(MyClass, self).currentmethod(alltheargsideclared, *args, **kwargs)``.
+- Never call :py:func:`super` with anything but the exact arguments you received, unless you really know what you're doing.
+- When you use it on methods whose acceptable arguments can be altered on a subclass via addition of more optional arguments, always accept ``*args, **kw``, and call :py:func:`super` like ``super(MyClass, self).currentmethod(alltheargsideclared, *args, **kwargs)``.
   If you don't do this, forbid addition of optional arguments in subclasses.
 - Never use positional arguments in ``__init__`` or ``__new__``.
   Always use keyword args, and always call them as keywords, and always pass all keywords on to :py:func:`super`.
 
-For guidance on successfully using :py:func:`super`, see Raymond Hettinger's article `Super Considered Super! <https://rhettinger.wordpress.com/2011/05/26/super-considered-super/>`__.
+For guidance on successfully using :py:func:`super`, see Raymond Hettinger's article `Super Considered Super! <https://rhettinger.wordpress.com/2011/05/26/super-considered-super/>`__
 
 .. _style-guide-py-comparisons:
 
@@ -557,8 +555,8 @@ For guidance on successfully using :py:func:`super`, see Raymond Hettinger's art
 
 .. _style-guide-py-comp-is:
 
-``is`` and ``is not`` SHOULD only be used if determining if two variables point to same object
-----------------------------------------------------------------------------------------------
+``is`` and ``is not`` SHOULD only be used for determining if two variables point to same object
+-----------------------------------------------------------------------------------------------
 
 Use ``is`` or ``is not`` only for the case that you need to know that two variables point to the exact same object.
 
@@ -578,7 +576,7 @@ This is also consistent with :pep:`8`, which `states <https://www.python.org/dev
 
    Comparisons to singletons like ``None`` should always be done with ``is`` or ``is not``, never the equality operators.
 
-For sequences, (`str`, `list`, `tuple`), use the fact that empty sequences are ``False``. 
+For sequences, (:py:obj:`str`, :py:obj:`list`, :py:obj:`tuple`), use the fact that empty sequences are ``False``. 
 
 Yes:
 

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -77,7 +77,7 @@ LSST DM Packages may also include a :file:`setup.cfg` file with :pep:`8` excepti
 
 	[flake8]
 	max-line-length = 110
-	ignore = E133, E226, E228, E251, N802, N803
+	ignore = E133, E226, E228, N802, N803
 
 :command:`flake8` can be invoked without arguments when this configuration is present.
 
@@ -146,7 +146,7 @@ Many PEP 8 issues in existing code can be fixed with `autopep8`_:
 .. code-block:: bash
 
    autopep8 . --in-place --recursive \
-       --ignore E133,E226,E228,N802,N803 --max-line-length 110
+       --ignore E133,E226,E228,N251,N802,N803 --max-line-length 110
 
 The ``.`` specifies the current directory.
 Together with ``--recursive``, the full tree of Python files will be processed by :command:`autopep8`.

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -528,42 +528,25 @@ Within a module, follow the order:
 8. Classes
 ==========
 
-Always decide whether a class's methods and instance variables (collectively: "attributes") should be public or non-public.
-If in doubt, choose non-public; it's easier to make it public later than to make a public attribute non-public.
-
-Public attributes are those that you expect unrelated clients of your class to use, with your commitment to avoid backward incompatible changes.
-Non-public attributes are those that are not intended to be used by third parties; you make no guarantees that non-public attributes won't change or even be removed.
-
-We don't use the term "private" here, since no attribute is really private in Python (without a generally unnecessary amount of work).
-Another category of attributes are those that are part of the "subclass API" (often called "protected" in other languages).
-Some classes are designed to be inherited from, either to extend or modify aspects of the class's behavior.
-When designing such a class, take care to make explicit decisions about which attributes are public, which are part of the subclass API, and which are truly only to be used by your base class.
-
-For simple public data attributes, it is best to expose just the attribute name, without complicated accessor/mutator methods.
-Keep in mind that Python provides an easy path to future enhancement, should you find that a simple data attribute needs to grow functional behavior.
-In that case, use properties to hide functional implementation behind simple data attribute access syntax.
-
-- Note 1: Properties only work on new-style classes.
-
-- Note 2: Try to keep the functional behavior side-effect free, although side-effects such as caching are generally fine.
-
-- Note 3: Avoid using properties for computationally expensive operations; the attribute notation makes the caller believe that access is (relatively) cheap.
+.. seealso:: `Designing for Inheritance <https://www.python.org/dev/peps/pep-0008/#id47>`__ in :pep:`8` for naming conventions related to public and private class APIs.
 
 .. _style-guide-py-super:
 
 ``super`` SHOULD NOT be used unless the author really understands the implications (e.g. in a well-understood multiple inheritance hierarchy).
 ----------------------------------------------------------------------------------------------------------------------------------------------
 
-Python provides ``super`` so that each parent class' method is only called once (see https://www.python.org/download/releases/2.3/mro/).
-The problem is, if you're going to use super at all, then all parent classes in the chain (also called the Method Resolution Order") need to use super otherwise the chain gets interrupted. 
-Other subtleties have been noted in https://fuhm.net/super-harmful/:
+Python provides :py:func:`super` so that each parent class' method is only called once.
+
+To use :py:func:`super`, all parent classes in the chain (also called the Method Resolution Order") need to use :py:func:`super` otherwise the chain gets interrupted. 
+Other subtleties have been noted in `an article by James Knight <https://fuhm.net/super-harmful/>`__:
 
 - Never call super with anything but the exact arguments you received, unless you really know what you're doing.
 - When you use it on methods whose acceptable arguments can be altered on a subclass via addition of more optional arguments, always accept ``*args, **kw``, and call ``super`` like ``super(MyClass, self).currentmethod(alltheargsideclared, *args, **kwargs)``.
   If you don't do this, forbid addition of optional arguments in subclasses.
 - Never use positional arguments in ``__init__`` or ``__new__``.
-  Always use keyword args, and always call them as keywords, and always pass all keywords on to ``super``.
+  Always use keyword args, and always call them as keywords, and always pass all keywords on to :py:func:`super`.
 
+For guidance on successfully using :py:func:`super`, see Raymond Hettinger's article `Super Considered Super! <https://rhettinger.wordpress.com/2011/05/26/super-considered-super/>`__.
 
 .. _style-guide-py-comparisons:
 

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -747,10 +747,12 @@ Not this:
  
 .. _style-guide-py-comments:
 
-13. Comments
+12. Comments
 ============
 
-.. _style-guide-py-13-1:
+Source code comments should follow `PEP 8's recommendations <https://www.python.org/dev/peps/pep-0008/#id29>`__ with the following additional requirements.
+
+.. _style-guide-py-comment-consistency:
 
 Comments MUST always remain up-to-date with code changes
 --------------------------------------------------------
@@ -758,22 +760,18 @@ Comments MUST always remain up-to-date with code changes
 Comments that contradict the code are worse than no comments.
 Always make a priority of keeping the comments up-to-date when the code changes!
 
-.. _style-guide-py-13-2:
+.. _style-guide-py-comment-sentence-spaces:
 
-Comments SHOULD be complete sentences
--------------------------------------
+Sentences in comments SHOULD NOT be separated by double spaces
+--------------------------------------------------------------
 
-Comments should be complete sentences.
-If a comment is a phrase or sentence, its first word should be capitalized, unless it is an identifier that begins with a lower case letter (never alter the case of identifiers!).
+Following PEP 8, comments should be complete sentences.
 
-If a comment is short, the period at the end can be omitted.
-Block comments generally consist of one or more paragraphs built out of complete sentences, and each sentence should end in a period.
+However, sentences **should not** be separated by two spaces; a single space is sufficient.
 
-You need not use two spaces after a sentence-ending period.
+`This differs from PEP 8 <https://www.python.org/dev/peps/pep-0008/#id29>`__.
 
-When writing English, *Strunk and White* apply.
-
-.. _style-guide-py-13-3:
+.. _style-guide-py-block-comment-indentation:
 
 Block comments SHOULD reference the code following them and SHOULD be indented to the same level
 ------------------------------------------------------------------------------------------------
@@ -781,36 +779,7 @@ Block comments SHOULD reference the code following them and SHOULD be indented t
 Block comments generally apply to some (or all) code that follows them, and are indented to the same level as that code.
 Each line of a block comment starts with a ``#`` and a single space (unless it is indented text inside the comment).
 
-Paragraphs inside a block comment are separated by a line containing a single #.
-
-.. _style-guide-py-13-4:
-
-Inline Comments MAY be sparingly used
--------------------------------------
-
-Use inline comments sparingly.
-Inline comments are unnecessary and in fact distracting if they state the obvious.
-
-Don't do this: 
-
-.. code-block:: py
-
-   x = x + 1      # Increment x
-
-But sometimes, this is useful: 
-
-.. code-block:: py
-
-   x = x + 1      # Compensate for border
-
-.. _style-guide-py-13-5:
-
-Inline comments SHOULD be separated by at least two spaces from the statement
------------------------------------------------------------------------------
-
-An inline comment is a comment on the same line as a statement.
-Inline comments should be separated by at least two spaces from the statement.
-They should start with a ``#`` (i.e., sharp sign and a single space).
+Paragraphs inside a block comment are separated by a line containing a single ``#``.
 
 .. _style-guide-py-docstrings:
 

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -75,25 +75,33 @@ LSST DM Packages may also include a :file:`setup.cfg` file with `PEP 8`_ excepti
 Summary of PEP 8 exceptions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-These error codes can be **ignored** by flake8_ when checking DM code against PEP 8 specifications:
+These error codes can be **ignored** by flake8_ when checking DM code against :pep:`8` specifications:
 
 E133
    Closing bracket is missing indentation.
+   This `pycodestyle error`_ (via flake8_) is not part of :pep:`8`.
 
 E226
    Missing whitespace around arithmetic operator.
+   See :ref:`style-guide-py-operator-whitespace`.
 
 E228
    Missing whitespace around bitwise or shift operator.
+   See :ref:`style-guide-py-operator-whitespace`.
 
 E251
    Unexpected spaces around keyword / parameter equals.
+   See :ref:`style-guide-py-multiline-assignment-whitespace`.
 
 N802
    Function name should be lowercase.
+   See :ref:`style-guide-py-naming`.
 
 N803
    Argument name should be lowercase.
+   See :ref:`style-guide-py-naming`.
+
+.. _pycodestyle error: http://pep8.readthedocs.io/en/latest/intro.html#error-codes
 
 .. _style-guide-py-noqa:
 
@@ -172,6 +180,7 @@ Class Attribute Names SHOULD be camelCase with leading lowercase
 ----------------------------------------------------------------
 
 `Opposes PEP 8 <https://www.python.org/dev/peps/pep-0008/#id45>`__.
+Error codes: N802 and N803.
 
 .. _style-guide-py-naming-functions:
 
@@ -179,6 +188,7 @@ Module methods (free functions) SHOULD be camelCase with leading lowercase
 --------------------------------------------------------------------------
 
 `Opposes PEP 8 <https://www.python.org/dev/peps/pep-0008/#id45>`__.
+Error code: N802.
 
 .. _style-guide-py-naming-class-modules:
 
@@ -709,6 +719,7 @@ For example:
    c = (a + b)*(a - b)
 
 This deviates from PEP 8, which `allows whitespace around these arithmetic operators if they appear alone <https://www.python.org/dev/peps/pep-0008/#id28>`__.
+Error codes: N226 and N228.
 
 .. _style-guide-py-multiline-assignment-whitespace:
 
@@ -744,6 +755,7 @@ Not this:
    aFunction(x, y, z, karg1 = value1, karg2 = value2, karg3 = value3)
 
 `Opposes PEP 8 <https://www.python.org/dev/peps/pep-0008/#id28>`__.
+Error code: N251.
  
 .. _style-guide-py-comments:
 

--- a/docs/py_docs.rst
+++ b/docs/py_docs.rst
@@ -467,9 +467,9 @@ An 'Attributes' section, located below the 'Parameters' section, may be used to 
 
    Attributes
    ----------
-   x : float
+   x : `float`
        The X coordinate.
-   y : float
+   y : `float`
        The Y coordinate.
 
 Attributes that are properties and have their :ref:`own docstrings <py-docstring-attribute-constants-structure>` can be simply listed by name:
@@ -539,7 +539,7 @@ Raises
 
    Raises
    ------
-   IOError
+   `IOError`
        If the file could not be read.
 
 This section should be used judiciously---only for errors that are non-obvious or have a large chance of getting raised.
@@ -576,7 +576,7 @@ When referring to an entirely different module or package, use the full namespac
 
 .. code-block:: rst
 
-   astropy.table.Tables : Flexible table data structures
+   `astropy.table.Tables` : Flexible table data structures
 
 Functions may be listed without descriptions; this is preferable if the functionality is clear from the function name:
 
@@ -749,11 +749,11 @@ In general, trust that the tables of contents in the user guide pages will provi
 
        Raises
        ------
-       ValueError : Input angles are outside range.
+       `ValueError` : Input angles are outside range.
        
        See also
        --------
-       GalacticCoordinate
+       `GalacticCoordinate`
 
        Examples
        --------
@@ -794,9 +794,9 @@ A minimal example:
 
        Parameters
        ----------
-       message : str
+       message : `str`
           Log message.
-       level : str
+       level : `str`
           Priority level of the log message.
        """
 
@@ -850,6 +850,6 @@ Acknowledgements
 
 These docstring guidelines are derived/adapted from in the `Numpy <https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`_ and `Astropy <http://docs.astropy.org/en/stable/_sources/development/docrules.txt>`_ documentation.
 
-Numpy is Copyright © 2005-2013, NumPy Developers.
+NumPy is Copyright © 2005-2013, NumPy Developers.
 
 Astropy is Copyright © 2011-2015, Astropy Developers.

--- a/docs/py_docs.rst
+++ b/docs/py_docs.rst
@@ -1,11 +1,6 @@
 #######################
-Documenting Python Code
+Documenting Python APIs
 #######################
-
-.. note::
-
-   This is a preview documentation format specification.
-   Software documentation should currently be written in the format described at https://confluence.lsstcorp.org/display/LDMDG/Documentation+Standards#DocumentationStandards-Python
 
 We document Python code in three ways:
 
@@ -21,102 +16,139 @@ We document Python code in three ways:
 
 3. By allowing Python objects to be introspected interactively with the ``__str__`` and ``__repr__`` magic methods.
 
-This page focuses on public code documentation through docstrings, while the latter two are discussed in our Python style guide.
+This page focuses on public code documentation through docstrings, while the latter two are discussed in our :doc:`../coding/python_style_guide`.
 
-.. TODO add link to python style guide.
+Treat the guidelines on this page as an extension of the :doc:`../coding/python_style_guide`.
 
-.. _py-doc-boilerplate:
-
-Boilerplate
-===========
-
-LSST's Python source files begin with a small amount of boilerplate text:
-
-.. Note: should this boilerplate be moved to our coding standard guide?
-
-.. code-block:: python
-
-   #
-   # LSST Data Management System
-   # See COPYRIGHT file at the top of the source tree.
-   #
-   # This product includes software developed by the
-   # LSST Project (http://www.lsst.org/).
-   #
-   # This program is free software: you can redistribute it and/or modify
-   # it under the terms of the GNU General Public License as published by
-   # the Free Software Foundation, either version 3 of the License, or
-   # (at your option) any later version.
-   #
-   # This program is distributed in the hope that it will be useful,
-   # but WITHOUT ANY WARRANTY; without even the implied warranty of
-   # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   # GNU General Public License for more details.
-   #
-   # You should have received a copy of the LSST License Statement and
-   # the GNU General Public License along with this program. If not,
-   # see <http://www.lsstcorp.org/LegalNotices/>.
-   #
+.. note::
+   Changes to this document must be approved by the System Architect (`RFC-24 <https://jira.lsstcorp.org/browse/RFC-24>`_).
+   To request changes to these standards, please file an :ref:`RFC <decision-making-rfc>`.
 
 .. _py-docstring-basics:
 
-Python Docstring Basics
-=======================
+Basic Format of Docstrings
+==========================
 
 Python docstrings are special strings that form the ``__doc__`` attributes attached to modules, classes, methods and functions.
-Docstrings are specified by `PEP-257`_.
+Docstrings are specified by :pep:`257`.
 
-.. _PEP-257: https://www.python.org/dev/peps/pep-0257/
+.. _py-docstring-triple-double-quotes:
 
-Docstrings are delimited by triple double quotes, ``"""``.
+Docstrings MUST be delimited by double triple quotes
+----------------------------------------------------
+
+Docstrings **must** be delimited by triple double quotes: ``"""``.
 This allows docstrings to span multiple lines.
+You may use ``u"""`` for unicode but it is usually preferable to stick to ASCII.
 
-Single line docstrings should have the delimiters and text all on one line:
+For consistency, *do not* use triple single quotes: ``'''``.
 
-.. code-block:: python
+.. _py-docstring-form:
 
-   """A one-line docstring."""
+Docstrings SHOULD be begin with ``"""`` and terminate with ``"""`` on its own line
+----------------------------------------------------------------------------------
 
-Such single line docstrings should only be considered acceptable for private (read: *undocumented*) APIs or for properties.
-Complete docstrings will span multiple lines.
+The docstring's summary sentence occurs on the same line as the opening ``"""``.
 
-When the docstring spans multiple lines, the first line of text should appear with the opening delimiter.
-The closing delimiter should appear on its own line:
+The terminating ``"""`` should be on its own line, even for 'one-line' docstrings (this is a minor departure from :pep:`257`).
+For example, a one-line docstring:
 
-.. code-block:: python
+.. code-block:: py
 
-   """Summary for a docstring.
-
-   More discussion in addition paragraphs.
-
-   And another paragraph.
+   """Sum numbers in an array.
    """
 
-By convention, the first paragraph of a multi-line docstring should be a single summary sentence.
+(*Note:* one-line docstrings are rarely used for public APIs, see :ref:`py-docstring-sections`.)
 
-**Do not place the opening delimeter on its own line,** as in:
+An example of a multi-paragraph docstring:
 
-.. code-block:: python
+.. code-block:: py
 
+   """Sum numbers in an array.
+
+   Parameters
+   ----------
+   values : iterable
+      Python interable whose values are summed.
+
+   Returns
+   -------
+   sum : `float`
+      Sum of `values`.
    """
-   Summary for a docstring.
 
-   Discussion how how the summary line should start on the same line as the
-   opening delimiter.
+.. _py-docstring-no-blanks:
 
-   And another paragraph.
+Docstrings SHOULD NOT be preceded or followed by a blank line
+-------------------------------------------------------------
+
+For example:
+
+.. code-block:: py
+
+   def sum(values):
+       """Sum numbers in an array.
+
+       Parameters
+       ----------
+       values : iterable
+          Python interable whose values are summed.
+
+       Returns
+       -------
+       sum : `float`
+          Sum of `values`.
+       """
+       pass
+
+.. _py-docstring-indentation:
+
+Docstring content MUST be indented with the code's scope
+--------------------------------------------------------
+
+For example:
+
+.. code-block:: py
+
+   def sum(values):
+       """Sum numbers in an array.
+
+       Parameters
+       ----------
+       values : iterable
+          Python interable whose values are summed.
+       """
+       pass
+
+Not:
+
+.. code-block:: py
+
+   def sum(values):
+       """Sum numbers in an array.
+
+   Parameters
+   ----------
+   values : iterable
+      Python interable whose values are summed.
    """
+       pass
 
 .. _py-docstring-placement:
 
 Docstring Placement
 ===================
 
+.. _py-docstring-module-placement:
+
 Modules
 -------
 
-Module-level docstrings must be placed as close to the top of the Python file as possible: *below* the boilerplate and any ``#!/usr/bin/env python``, but *above* the imports.
-Module-level docstrings should not be indented.
+Module-level docstrings must be placed as close to the top of the Python file as possible: *below* any ``#!/usr/bin/env python`` and license statements, but *above* imports.
+See also: :ref:`style-guide-py-file-order`.
+
+Module docstrings should not be indented.
+For example:
 
 .. code-block:: python
    
@@ -138,10 +170,12 @@ Module-level docstrings should not be indented.
    import lsst.afw.table as afw_table
    # [...]
 
+.. _py-docstring-class-method-function-placement:
+
 Classes, Methods, and Functions
 -------------------------------
 
-Class/method/function docstrings must be placed directly below the class/method/function declaration, and indented to the level of the scope.
+Class/method/function docstrings must be placed directly below the declaration, and indented according to the code scope.
 
 .. code-block:: python
 
@@ -161,6 +195,7 @@ Class/method/function docstrings must be placed directly below the class/method/
            """
            pass
 
+
    def my_function():
        """Summary of my_function.
 
@@ -168,21 +203,23 @@ Class/method/function docstrings must be placed directly below the class/method/
        """
        pass
 
-Note that the class docstring takes the place of a docstring of the ``__init__`` method; ``__init__`` has no docstring.
+Note that the class docstring takes the place of a docstring for the ``__init__`` method; ``__init__`` has no docstring.
 
-.. _py-doc-docstring-rst:
+.. _py-docstring-rst:
 
 ReStructuredText in Docstrings
 ==============================
 
 We use reStructuredText to mark up and give semantic meaning to text in docstrings.
-ReStructuredText is lightweight enough to read in raw form, such as command line terminal printout.
-All of the style guidance for using restructured text from our :doc:`ReStructuredText Style Guide <rst_styleguide>` applies in docstrings with a few exceptions defined here.
+ReStructuredText is lightweight enough to read in raw form, such as command line terminal printouts, but is also parsed and rendered with our Sphinx-based documentation build system.
+All of the style guidance for using reStructuredText from our :doc:`rst_styleguide` applies in docstrings with a few exceptions defined here.
+
+.. _py-docstring-nospace-headers:
 
 No space between headers and paragraphs
 ---------------------------------------
 
-For docstrings the numpydoc standard is to omit any space between a header and the following paragraph.
+For docstrings, the Numpydoc_ standard is to omit any space between a header and the following paragraph.
 
 For example
 
@@ -195,21 +232,21 @@ For example
    A paragraph
    """
 
-This deviation from the normal style guide is in keeping with Python community idioms, and to save vertical space in terminal help printouts.
+This :ref:`deviation from the normal style guide <rst-sectioning>` is in keeping with Python community idioms and to save vertical space in terminal help printouts.
 
-.. _py-doc-section-levels:
+.. _py-docstring-section-levels:
 
 Top level headers are defined with '-'
 --------------------------------------
 
-In docstrings, the top level header is marked up with a ``-``, the third level listed in our ReStructuredTextStyle guide.
+In docstrings, the top level header is marked up with a ``-``, the third level listed in our :ref:`ReStructuredText Style Guide <rst-sectioning>`.
 The header hierarchy is thus:
 
 1. Sections ``-``,
 2. Subsections ``^``,
 3. Subsubsections ``"``.
 
-This deviation from our :ref:`reST style guide <rst-sectioning>` is in keeping with Numpy community idioms, and required by our Sphinx tooling.
+This deviation from our :ref:`reST Style Guide <rst-sectioning>` is in keeping with NumPy community idioms, and required by our Sphinx tooling.
 
 .. FIXME uncomment this when RFC-107 is decided
 ..
@@ -229,47 +266,47 @@ Common Structure of Docstrings
 ==============================
 
 We organize Python docstrings into sections that appear in a common order.
-This format follows the `Numpydoc`_ standard (used by NumPy, SciPy, and Astropy, among other scientific Python packages) rather than the format described in `PEP-287`_.
+This format follows the `Numpydoc`_ standard (used by NumPy, SciPy, and Astropy, among other scientific Python packages) rather than the format described in :pep:`287`.
+The sections and their relative order is:
 
 .. _Numpydoc: https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
-
-.. _PEP-287: https://www.python.org/dev/peps/pep-0287/
 
 1. :ref:`Short Summary <py-docstring-short-summary>`
 2. :ref:`Deprecation Warning <py-docstring-deprecation>` (if applicable)
 3. :ref:`Extended Summary <py-docstring-extended-summary>` (optional)
-4. :ref:`Parameters <py-docstring-parameters>` (if applicable; for classes, methods and functions)
+4. :ref:`Parameters <py-docstring-parameters>` (if applicable; for classes, methods, and functions)
 5. :ref:`Methods <py-docstring-methods>` (if applicable; for classes)
 6. :ref:`Attributes <py-docstring-attributes>` (if applicable; for classes)
 7. :ref:`Returns <py-docstring-returns>` or :ref:`Yields <py-docstring-yields>` (if applicable; for functions, methods, and generators)
-8. :ref:`Other Parameters <py-docstring-other-parameters>` (if applicable; for classes, methods and functions)
+8. :ref:`Other Parameters <py-docstring-other-parameters>` (if applicable; for classes, methods, and functions)
 9. :ref:`Raises <py-docstring-raises>` (if applicable)
 10. :ref:`See Also <py-docstring-see-also>` (optional)
 11. :ref:`Notes <py-docstring-notes>` (optional)
 12. :ref:`References <py-docstring-references>` (optional)
 13. :ref:`Examples <py-docstring-examples>` (optional)
 
-In the following sections we describe the content of these docstring sections and provide examples of full docstrings composed for classes, methods, functions, and constants.  
+For summaries of how these docstring sections are composed in specific contexts, see:
+
+- :ref:`py-docstring-module-structure`
+- :ref:`py-docstring-class-structure`
+- :ref:`py-docstring-method-function-structure`
+- :ref:`py-docstring-attribute-constants-structure`
 
 .. _py-docstring-short-summary:
 
 Short Summary
 -------------
 
-A one-line summary that does not use variable names or the function name:
+A one-line summary that does not use variable names or the function's name:
 
 .. code-block:: python
 
    def add(a, b):
-       """Sum two numbers."""
+       """Sum two numbers.
+       """
        return a + b
 
-The summary should be written as a present-tense action.
-*Do not write something like "Sums two numbers."*
-
-The one line summary can be used alone only in *extremely* trivial cases, such as Python properties.
-Keep in mind our `style guideline for placing the short summary on the same line as the opening (and closing, if used alone) docstring delimiters <py-docstring-basics>`_.
-In virtually all cases using a full multi-line docstring is the correct thing to do.
+For functions and methods, the summary should be written in the imperative voice (i.e., as a command that the API consumer is giving).
 
 .. _py-docstring-deprecation:
 
@@ -297,8 +334,8 @@ Extended Summary
 ----------------
 
 A few sentences giving an extended description.
-This section should be used to clarify *functionality*, not to discuss implementation detail or background theory, which should rather be explored in the :ref:`Notes <py-docstring-notes>` section below.
-You may refer to the parameters and the function name, but parameter descriptions still belong in the :ref:`Parameters <py-docstring-parameters>` section.
+This section should be used to clarify *functionality*, not to discuss implementation detail or background theory, which should rather be explored in the :ref:`'Notes' <py-docstring-notes>` section below.
+You may refer to the parameters and the function name, but parameter descriptions still belong in the :ref:`'Parameters' <py-docstring-parameters>` section.
 
 .. _py-docstring-parameters:
 
@@ -307,7 +344,7 @@ Parameters
 
 *For functions, methods and classes.*
 
-*Parameters* is a description of the function arguments, keywords and their respective types.
+'Parameters' is a description of a function or method's arguments and their respective types.
 
 .. code-block:: rst
 
@@ -316,36 +353,42 @@ Parameters
    x : type
        Description of parameter `x`.
 
-Notice that the description is **indented by four spaces** from the ``{name} : {type}`` line of each argument.
+Notice that the description is **indented by four spaces** from the prior ``{name} : {type}`` line of each argument.
 If a description spans more than one line, the continuation lines must be indented to the same level.
 
-Arguments should be listed in the same order as they appear in the function signature.
+Arguments should be listed in the same order as they appear in the function or method signature.
 
-When describing an argument in the description, enclose the name of the variable in single backticks (the default role in reST, which is Python-aware in docstrings).
+.. _py-docstring-parameter-types:
 
 Parameter Types
 ^^^^^^^^^^^^^^^
 
-For the parameter types, be as precise as possible.
+Be as precise as possible when describing types for parameters.
+The type description is free-form text, making it possible to list several supported types or indicate nuances.
+Complex and lengthy descriptions can be moved to the *description* field.
 
 .. code-block:: rst
 
    Parameters
    ----------
-   filename : str
+   filename : `str`
        Description of `filename`.
-   copy : bool
+   copy : `bool`
        Description of `copy`.
    dtype : data-type
        Description of `dtype`.
    iterable : iterable object
        Description of `iterable`.
-   shape : int or tuple of int
+   shape : `int` or `tuple` of int
        Description of `shape`.
-   files : list of str
+   files : `list` of `str`
        Description of `files`.
 
-For instances of classes, provide the full namespace to the class.
+Note that concrete types are wrapped in backticks, which is the *default role* in reStructuredText.
+When possible, Sphinx will make a link to the API reference for that object using `intersphinx <http://www.sphinx-doc.org/en/stable/ext/intersphinx.html>`_.
+(In docstrings, ``:py:obj:`` is the :ref:`default role <rst-python-link>`.)
+
+For instances of classes, provide the full namespace to the class, such as ```lsst.afw.table.ExposureTable```.
 
 When a parameter can only assume one of a fixed set of values, those values can be listed in braces:
 
@@ -354,33 +397,34 @@ When a parameter can only assume one of a fixed set of values, those values can 
    order : {'C', 'F', 'A'}
        Description of `order`.
 
+.. _py-docstring-optional:
+
 Optional Parameters
 ^^^^^^^^^^^^^^^^^^^
 
-For keyword arguments, add ``optional`` to the type specification:
+For keyword arguments, add 'optional' to the type specification:
 
 .. code-block:: rst
 
-   x : int, optional
+   x : `int`, optional
 
-Optional keyword parameters have default values, which are displayed as
-part of the function signature. They can also be detailed in the
-description:
+Optional keyword parameters have default values, which are automatically documented as part of the function or method's signature.
+Default values can also be detailed in the description:
 
 .. code-block:: rst
 
    Parameters
    ----------
-   x : type
+   x : `int`, optional
        Description of parameter `x` (the default is -1, which implies summation
        over all axes).
 
+.. _py-docstring-shorthand:
 
 Shorthand
 ^^^^^^^^^
 
-When two or more input parameters have exactly the same type, shape and
-description, they can be combined:
+When two or more consecutive input parameters have exactly the same type, shape and description, they can be combined:
 
 .. code-block:: rst
 
@@ -394,7 +438,7 @@ Methods
 
 *For classes.*
 
-If a class has a very large number of methods, which are hard to discover, an additional *Methods* section *can* be provided to list them:
+If a class has a very large number of methods, which are hard to discover, an additional 'Methods' section *can* be provided to list them:
 
 .. code-block:: rst
 
@@ -405,8 +449,8 @@ If a class has a very large number of methods, which are hard to discover, an ad
    sort(column, order='ascending')
       Sort by `column`
 
-Do not list private methods in the Methods section.
-If it is necessary to explain a private method (use with care!), it can be referred to in the :ref:`Extended Summary <py-docstring-extended-summary>` or :ref:`Notes <py-docstring-notes>` sections.
+Do not list private methods in the 'Methods' section.
+If it is necessary to explain a private method (use with care!), it can be mentioned in the :ref:`Extended Summary <py-docstring-extended-summary>` or :ref:`Notes <py-docstring-notes>` sections.
 
 Do not list ``self`` as the first parameter of a method.
 
@@ -417,8 +461,7 @@ Attributes
 
 *For classes.*
 
-An ``Attributes`` section, located below the ``Parameters`` section, may be
-used to describe class variables:
+An 'Attributes' section, located below the 'Parameters' section, may be used to describe class variables:
 
 .. code-block:: rst
 
@@ -429,8 +472,7 @@ used to describe class variables:
    y : float
        The Y coordinate.
 
-Attributes that are properties and have their own docstrings can be simply
-listed by name:
+Attributes that are properties and have their :ref:`own docstrings <py-docstring-attribute-constants-structure>` can be simply listed by name:
 
 .. code-block:: rst
 
@@ -438,9 +480,9 @@ listed by name:
    ----------
    real
    imag
-   x : float
+   x : `float`
        The X coordinate
-   y : float
+   y : `float`
        The Y coordinate
 
 .. _py-docstring-returns:
@@ -450,7 +492,7 @@ Returns
 
 *For functions and methods*.
 
-*Returns* is an explanation of the returned values and their types, of the same format as `Parameters <py-docstring-parameters>`_.
+'Returns' is an explanation of the returned values and their types, in the same format as :ref:`'Parameters' <py-docstring-parameters>`.
 
 If a sequence of values is returned, each value may be separately listed, in order:
 
@@ -458,9 +500,9 @@ If a sequence of values is returned, each value may be separately listed, in ord
 
    Returns
    -------
-   x : int
+   x : `int`
        Description of x.
-   y : int
+   y : `int`
        Description of y.
 
 If a return type is `dict`, ensure that the key-value pairs are documented in the description.
@@ -472,7 +514,7 @@ Yields
 
 *For generators.*
 
-*Yields* is used identically to `Returns <py-docstring-yields>`_, but for generators.
+'Yields' is used identically to :ref:`'Returns' <py-docstring-yields>`, but for generators.
 
 .. _py-docstring-other-parameters:
 
@@ -481,7 +523,7 @@ Other Parameters
 
 *For classes, methods and functions.*
 
-*Other Parameters* is an optional section used to describe infrequently used parameters.
+'Other Parameters' is an optional section used to describe infrequently used parameters.
 It should only be used if a function has a large number of keyword parameters, to prevent cluttering the :ref:`Parameters <py-docstring-parameters>` section.
 
 .. _py-docstring-raises:
@@ -491,7 +533,7 @@ Raises
 
 *For classes, methods and functions.*
 
-*Raises* is an optional section detailing which errors get raised and under what conditions:
+'Raises' is an optional section detailing which errors get raised and under what conditions:
 
 .. code-block:: rst
 
@@ -507,7 +549,7 @@ This section should be used judiciously---only for errors that are non-obvious o
 See Also
 --------
 
-*See Also* is an optional section used to refer to related code.
+'See Also' is an optional section used to refer to related code.
 This section can be very useful, but should be used judiciously.
 The goal is to direct users to other functions they may not be aware of, or have easy means of discovering (by looking at the module docstring, for example).
 Routines whose docstrings further explain parameters used by this function are good candidates.
@@ -518,8 +560,8 @@ As an example, for a function such as ``numpy.cos``, we would have
 
    See Also
    --------
-   sin : Compute an element-wise Sine function.
-   tan : Compute an element-wise Tangent function.
+   `sin` : Compute an element-wise Sine function.
+   `tan` : Compute an element-wise Tangent function.
 
 When referring to functions in the same sub-module, no prefix is needed, and the tree is searched upwards for a match.
 
@@ -528,7 +570,7 @@ E.g., whilst documenting a ``lsst.afw.tables`` module, refer to a class in ``lss
 
 .. code-block:: rst
 
-   afw.detection.Footprint : Regular detection footprint.
+   `afw.detection.Footprint` : Regular detection footprint.
 
 When referring to an entirely different module or package, use the full namespace.
 
@@ -542,9 +584,9 @@ Functions may be listed without descriptions; this is preferable if the function
 
    See Also
    --------
-   func_a : Function a with its description.
-   func_b, func_c, func_d
-   func_e
+   `func_a` : Function a with its description.
+   `func_b`, `func_c`, `func_d`
+   `func_e`
    
 .. _py-docstring-notes:
 
@@ -560,7 +602,7 @@ This section may include mathematical equations, written in `LaTeX <http://www.l
 
   .. math:: X(e^{j\omega } ) = x(n)e^{ - j\omega n}
 
-Equations can also be typeset underneath the math directive:
+Longer equations can also be typeset underneath the math directive:
 
 .. code-block:: rst
 
@@ -571,7 +613,7 @@ Equations can also be typeset underneath the math directive:
      x(n) * y(n) \Leftrightarrow X(e^{j\omega } )Y(e^{j\omega } )\\
      another equation here
 
-Math can furthermore be used inline:
+Math can also be used inline:
 
 .. code-block:: rst
 
@@ -583,6 +625,8 @@ Variable names are displayed in typewriter font, obtained by using ``\mathtt{var
 
    We square the input parameter `alpha` to obtain
    :math:`\mathtt{alpha}^2`.
+
+See :ref:`rst-math` for more details on math typesetting in reStructuredText.
 
 Note that LaTeX is not particularly easy to read, so use equations sparingly.
 
@@ -600,7 +644,7 @@ where filename is a path relative to the reference guide source directory.
 References
 ----------
 
-References cited in the :ref:`Notes <py-docstring-notes>` section may be listed here, e.g. if you cited the article below using the text ``[1]_``, include it as in the list as follows:
+References cited in the :ref:`'Notes' <py-docstring-notes>` section may be listed here, e.g. if you cited the article below using the text ``[1]_``, include it as in the list as follows:
 
 .. code-block:: rst
 
@@ -612,14 +656,17 @@ References cited in the :ref:`Notes <py-docstring-notes>` section may be listed 
 
 Note that Web pages should be referenced with regular inline links.
 
-References are meant to augment the docstring, but should not be required to understand it. References are numbered, starting from one, in the order in which they are cited.
+References are meant to augment the docstring, but should not be required to understand it.
+References are numbered, starting from one, in the order in which they are cited.
+
+We may support `bibtex-based references instead <https://github.com/mcmtroffaes/sphinxcontrib-bibtex>`__ instead of explicitly writing bibliographies in docstrings.
 
 .. _py-docstring-examples:
 
 Examples
 --------
 
-*Examples* is an optional section for examples, using the `doctest <http://docs.python.org/library/doctest.html>`_ format.
+'Examples' is an optional section for examples, using the `doctest <http://docs.python.org/library/doctest.html>`_ format.
 These examples do not replace unit tests, but *are* intended to be tested to ensure documentation and code is consistent.
 While optional, this section is very strongly encouraged.
 
@@ -647,6 +694,8 @@ It is not necessary to use the doctest markup ``<BLANKLINE>`` to indicate empty 
 
 .. The examples may assume that ``import numpy as np`` is executed before the example code.
 
+.. _py-docstring-module-structure:
+
 Documenting Modules
 ===================
 
@@ -659,6 +708,8 @@ Module docstrings contain the following sections:
 4. :ref:`See Also <py-docstring-see-also>` (optional)
 
 .. TODO Provide an example
+
+.. _py-docstring-class-structure:
 
 Documenting Classes
 ===================
@@ -680,7 +731,7 @@ Class docstrings contain the following sections:
 12. :ref:`Examples <py-docstring-examples>` (optional)
 
 Note that the `Methods <py-docstring-methods>`_ section is only used if the method list is extremely long.
-In general, trust that the tables to contents in the user guide pages will provide useful summaries of a class's methods.
+In general, trust that the tables of contents in the user guide pages will provide useful summaries of a class's methods.
 
 .. code-block:: python
 
@@ -715,6 +766,7 @@ In general, trust that the tables to contents in the user guide pages will provi
        def __init__(self, ra, dec, frame='icrs'):
            pass
 
+.. _py-docstring-method-function-structure:
 
 Documenting Methods and Functions
 =================================
@@ -748,9 +800,10 @@ A minimal example:
           Priority level of the log message.
        """
 
+.. _py-docstring-attribute-constants-structure:
 
-Documenting constants, class properties, attributes
-===================================================
+Documenting Constants, Class Properties, and Attributes
+=======================================================
 
 Constants in modules, and properties and attributes in classes are all similar in that their values are accessed with arguments.
 At minimum, constants/properties/attributes should have a summary line, but can also have a more complete structure with sections:
@@ -799,4 +852,4 @@ These docstring guidelines are derived/adapted from in the `Numpy <https://githu
 
 Numpy is Copyright © 2005-2013, NumPy Developers.
 
-Astropy is Copyright (c) 2011-2015, Astropy Developers.
+Astropy is Copyright © 2011-2015, Astropy Developers.

--- a/docs/rst_styleguide.rst
+++ b/docs/rst_styleguide.rst
@@ -179,8 +179,8 @@ We create section hierarchies as follows:
 This specific sequence of section markup styles is not mandated by the reST specification, but we encourage you to use it for consistency across all DM reST documents.
 
 **Sections in Python docstrings are a special case.**
-First, :ref:`we do not place a blank space between a section header and the object lists below <py-doc-docstring-rst>`.
-Second, :ref:`Python docstrings can only use subsection and subsubsection-level headings <py-doc-section-levels>`.
+First, :ref:`we do not place a blank space between a section header and the object lists below <py-docstring-nospace-headers>`.
+Second, :ref:`Python docstrings can only use subsection and subsubsection-level headings <py-docstring-section-levels>`.
 
 .. _rst-linking:
 
@@ -743,7 +743,9 @@ RestructuredText Formatting Conventions
 Text wrapping
 -------------
 
-When writing reST documentation in Python files, documentation lines should be kept to lengths of :ref:`75 characters or fewer <py-doc-docstring-rst>` (discounting leading indentation).
+When writing reST documentation in Python docstrings, documentation lines should be wrapped at lengths of 110 characters for :ref:`consistency with our Python Style Guide <style-guide-py-line-length>`.
+
+.. NOTE: ls.st/rfc-107
 
 For reStructuredText documents (e.g., ``.rst`` files), reST doesn't care about line formatting.
 Emacs users, for example, are free to use hard-wrap formatting lines at 72 characters if that helps you write docs.

--- a/processes/workflow.rst
+++ b/processes/workflow.rst
@@ -433,6 +433,8 @@ In addition, if this update affects users, a short description of its effects fr
 Appendix: Commit Organization Best Practices
 ============================================
 
+.. _git-commit-organization-logical-units:
+
 Commits should represent discrete logical changes to the code
 -------------------------------------------------------------
 


### PR DESCRIPTION
This PR updates the Python Style Guide in response to two accepted RFCs:

- [RFC 162: LSST Python Style Guide delta to PEP 8](http://ls.st/rfc-162)
- [RFC 214: Use numpydoc docstrings](http://ls.st/rfc-214)

Both the 'Python Style Guide' and 'Documenting Python APIs' pages are being updated in the same ticket since they effectively form the Python Style Guide as a whole—the numpydoc material is simply too detailed to include with the rest of the style guide.

Live preview of these revised pages:

- https://developer.lsst.io/v/DM-5456/coding/python_style_guide.html
- https://developer.lsst.io/v/DM-5456/docs/py_docs.html