### PR TITLE
DM-7526: Copy edits to the Python Style Guide & Numpydoc Guide

### DIFF
--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -13,12 +13,12 @@ The :doc:`intro` provides the overarching Coding Standards policy applicable to 
 .. contents::
    :depth: 4
 
-.. _style-guide-py-intro:
+.. _style-guide-py-version:
 
 0. Python Version
 =================
 
-.. _style-guide-py-version:
+.. _style-guide-py-version-py3:
 
 All DM Python code MUST work with Python 3
 ------------------------------------------
@@ -26,6 +26,8 @@ All DM Python code MUST work with Python 3
 All the Python code written by LSST Data Management must be runnable using Python 3.
 Python 2 will cease to be supported before LSST is operational (:pep:`373`).
 The current baseline version is Python 3.5.
+
+.. _style-guide-py-version-external-users:
 
 DM Python library code with an external user base MUST support Python 2.7 and 3.x
 ---------------------------------------------------------------------------------
@@ -37,6 +39,8 @@ In particular, the Science Pipelines code (commonly referred to as ``lsst_distri
 Standalone applications, code providing services, and internal programs and modules (such as Qserv, SQuaSH and ``dax``) do not have to support Python 2.
 If code is currently supporting both 2.7 and 3.x, dropping support for Python 2.7 requires an :ref:`RFC <decision-making-rfc>`.
 New code that has never supported Python 2.7 and which will not be externally usable library code or a dependency of a package that supports 2.7 does not require an RFC to request that 2.7 is not supported.
+
+.. _style-guide-py-pep8-baseline:
 
 1. PEP 8 is the Baseline Coding Style
 =====================================

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -45,7 +45,7 @@ New code that has never supported Python 2.7 and which will not be externally us
 1. PEP 8 is the Baseline Coding Style
 =====================================
 
-Data Management's Python coding style is based the `PEP 8 Style Guide for Python Code <https://www.python.org/dev/peps/pep-0008/>`_ with modifications specified in this document.
+Data Management's Python Coding Style is based on the `PEP 8 Style Guide for Python Code <https://www.python.org/dev/peps/pep-0008/>`_ with modifications specified in this document.
 
 :pep:`8` is used throughout the Python community and should feel familiar to Python developers.
 DM's deviations from :pep:`8` are primarily motivated by consistency with the :doc:`cpp_style_guide`.
@@ -56,8 +56,8 @@ Additional guidelines are included in this document to address specific requirem
 Exceptions to PEP 8
 -------------------
 
-The following table summarizes all :pep:`8` guidelines are **not followed** by the DM Python Style Guide.
-These exceptions are phrased as error codes that may be ignored by the flake8_ linter (see :ref:`style-guide-py-flake8`).
+The following table summarizes all :pep:`8` guidelines that are **not followed** by the DM Python Style Guide.
+These exceptions are organized by error codes that may be ignored by the flake8_ linter (see :ref:`style-guide-py-flake8`).
 
 E133
    Closing bracket is missing indentation.
@@ -94,13 +94,13 @@ Code MAY be validated with flake8
 ---------------------------------
 
 The flake8_ tool may be used to validate Python source code against the portion of :pep:`8` adopted by Data Management.
-In addition, flake8_ statically checks Python for code errors.
-The separate `pep8-naming`_ plugin validates names according to the DM Python coding style.
+Additionally, flake8_ statically checks Python for code errors.
+The separate `pep8-naming`_ plugin validates names according to the DM Python Style Guide.
 
 .. note::
 
    Flake8 only validates code against PEP 8 specifications.
-   This style guide includes additional guidelines *are not* automatically linted.
+   This style guide includes additional guidelines that *are not* automatically linted.
 
 .. _flake8: https://flake8.readthedocs.io
 .. _pep8-naming: http://pypi.python.org/pypi/pep8-naming
@@ -129,7 +129,7 @@ Flake8 command line invocation
 This command lints all Python files in the current directory.
 Alternatively, individual files can be specified in place of ``.``.
 
-The ignored error codes are :ref:`explained below <style-guide-py-ignored-errors>`.
+The ignored error codes are :ref:`explained above <style-guide-py-ignored-errors>`.
 
 .. _style-guide-py-flake8-config:
 
@@ -151,7 +151,7 @@ LSST DM Packages may also include a :file:`setup.cfg` file with :pep:`8` excepti
 Lines that intentionally deviate from DM's PEP 8 MUST include a ``noqa`` comment
 --------------------------------------------------------------------------------
 
-Lines of code may intentionally deviate from our application of PEP 8 (see above) because of limitations in flake8_.
+Lines of code may intentionally deviate from our application of PEP 8 because of limitations in flake8_.
 In such cases, authors must append a ``# noqa`` comment to the line that includes the specific error code being ignored.
 `See the flake8 documentation for details <https://flake8.readthedocs.io/en/latest/user/ignoring-errors.html#in-line-ignoring-errors>`__ .
 This prevents the line from triggering false flake8_ warnings to other developers, while also linting unexpected errors.
@@ -186,7 +186,7 @@ Alternatively, a single file can be specified in place of ``.``.
 
 :command:`autopep8`\ ʼs changes must always be validated before committing.
 
-Style changes must be encapsulated in a distinct commit (see :ref:`git-commit-organization-logical-units` in :doc:`Workflow document <../processes/workflow>`).
+Style changes must be encapsulated in a distinct commit (see :ref:`git-commit-organization-logical-units` in :doc:`../processes/workflow`).
 
 .. note::
 
@@ -278,7 +278,7 @@ Consistency with the LSST C++ Coding Standards namespaces exists.
 
 - ``import lsst.foo.bar as fooBar`` is analogous to ``namespace fooBar = lsst::foo::bar``
 
-**Disallowed** in both Coding Standards (except in :file:`__init__.py` library initialization context):
+**Disallowed** in both Coding Standards (except in :file:`__init__.py` library initialization contexts):
 
 - ``from lsst.foo.bar import *`` is analogous to ``using namespace lsst::foo::bar``
 
@@ -401,7 +401,7 @@ Always make a priority of keeping the comments up-to-date when the code changes!
 Sentences in comments SHOULD NOT be separated by double spaces
 --------------------------------------------------------------
 
-Following PEP 8, comments should be complete sentences.
+Following :pep:`8`, comments should be complete sentences.
 
 However, sentences **should not** be separated by two spaces; a single space is sufficient.
 
@@ -424,9 +424,11 @@ Paragraphs inside a block comment are separated by a line containing a single ``
 
 Use **Numpydoc** to format the content of all docstrings.
 The page :doc:`../docs/py_docs` authoritatively describes this format.
-Its guidelines should be treated as an extension of this Python style guide.
+Its guidelines should be treated as an extension of this Python Style Guide.
 
-See also the :doc:`../docs/rst_styleguide` and the :ref:`rst-formatting-guidelines` section in particular for guidelines on reStructuredText in general.
+.. seealso::
+
+   The :doc:`../docs/rst_styleguide`---and the :ref:`rst-formatting-guidelines` section in particular---provide guidelines on reStructuredText in general.
 
 .. _style-guide-py-docstring-public-api:
 
@@ -592,7 +594,7 @@ For guidance on successfully using :py:func:`super`, see Raymond Hettinger's art
 
 Use ``is`` or ``is not`` only for the case that you need to know that two variables point to the exact same object.
 
-To test equality in *value*, use ``==`` or ``!=`` instead.
+To test for equality in *value*, use ``==`` or ``!=`` instead.
 
 .. _style-guide-py-comp-none:
 
@@ -688,9 +690,9 @@ A mutable object MUST NOT be used as a keyword argument default
 Never use a mutable object as default value for a keyword argument in a function or method.
 
 When used a mutable is used as a default keyword argument, the default *can* change from one call to another leading to unexpected behavior.
-This issue can be avoided by only using immutable types as default.
+This issue can be avoided by only using immutable types as defaults.
 
-For example, rather than provide a default empty list:
+For example, rather than provide an empty list as a default:
 
 .. code-block:: py
 

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -140,12 +140,11 @@ LSST DM Packages may also include a :file:`setup.cfg` file with :pep:`8` excepti
 
 .. code-block:: ini
 
-	[flake8]
-	max-line-length = 110
-	ignore = E133, E226, E228, N802, N803
+   [flake8]
+   max-line-length = 110
+   ignore = E133, E226, E228, N802, N803
 
 :command:`flake8` can be invoked without arguments when this configuration is present.
-
 
 .. _style-guide-py-noqa:
 

--- a/docs/py_docs.rst
+++ b/docs/py_docs.rst
@@ -266,7 +266,7 @@ Common Structure of Docstrings
 ==============================
 
 We organize Python docstrings into sections that appear in a common order.
-This format follows the `Numpydoc`_ standard (used by NumPy, SciPy, and Astropy, among other scientific Python packages) rather than the format described in :pep:`287`.
+This format follows the `Numpydoc`_ format (used by NumPy, SciPy, and Astropy, among other scientific Python packages) rather than the format described in :pep:`287`.
 The sections and their relative order is:
 
 .. _Numpydoc: https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
@@ -667,7 +667,7 @@ Examples
 --------
 
 'Examples' is an optional section for examples, using the `doctest <http://docs.python.org/library/doctest.html>`_ format.
-These examples do not replace unit tests, but *are* intended to be tested to ensure documentation and code is consistent.
+These examples do not replace unit tests, but *are* intended to be tested to ensure documentation and code are consistent.
 While optional, this section is very strongly encouraged.
 
 When multiple examples are provided, they should be separated by blank lines.
@@ -777,7 +777,7 @@ Method and function docstrings contain the following sections:
 2. :ref:`Deprecation Warning <py-docstring-deprecation>` (if applicable)
 3. :ref:`Extended Summary <py-docstring-extended-summary>` (optional)
 4. :ref:`Parameters <py-docstring-parameters>` (if applicable)
-5. :ref:`Returns <py-docstring-returns>` or `Yields <py-docstring-yields>` (if applicable)
+5. :ref:`Returns <py-docstring-returns>` or :ref:`Yields <py-docstring-yields>` (if applicable)
 6. :ref:`Other Parameters <py-docstring-other-parameters>` (if applicable)
 7. :ref:`Raises <py-docstring-raises>` (if applicable)
 8. :ref:`See Also <py-docstring-see-also>` (optional)
@@ -817,7 +817,7 @@ At minimum, constants/properties/attributes should have a summary line, but can 
 
 In the short summary, a description of the type should be included:
 
-.. code-block:: rst
+.. code-block:: py
 
    NAME = 'LSST'
    """Name of the project (str)"""
@@ -825,7 +825,7 @@ In the short summary, a description of the type should be included:
 Note that class attributes can alternatively be documented in an :ref:`Attributes <py-docstring-attributes>` section of the class's docstring.
 This is particularly useful when the attribute is not set in the class scope, but rather in a method such as ``__init__``.
 
-.. code-block:: rst
+.. code-block:: py
 
    class Answer(object):
        """Container for the answer.
@@ -848,7 +848,7 @@ This is particularly useful when the attribute is not set in the class scope, bu
 Acknowledgements
 ================
 
-These docstring guidelines are derived/adapted from in the `Numpy <https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`_ and `Astropy <http://docs.astropy.org/en/stable/_sources/development/docrules.txt>`_ documentation.
+These docstring guidelines are derived/adapted from the `NumPy <https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`_ and `Astropy <http://docs.astropy.org/en/stable/_sources/development/docrules.txt>`_ documentation.
 
 NumPy is Copyright © 2005-2013, NumPy Developers.
 


### PR DESCRIPTION
- https://developer.lsst.io/v/DM-7526/coding/python_style_guide.html
- https://developer.lsst.io/v/DM-7526/docs/py_docs.html