### PR TITLE
Fix spelling: interable -> iterable

### DIFF
--- a/docs/py_docs.rst
+++ b/docs/py_docs.rst
@@ -69,7 +69,7 @@ An example of a multi-paragraph docstring:
    Parameters
    ----------
    values : iterable
-      Python interable whose values are summed.
+      Python iterable whose values are summed.
 
    Returns
    -------


### PR DESCRIPTION
I saw the "interable" typo in one of the docstring examples. I assume I don't actually need to fill out an RFC for changes on this level...