### PR TITLE
DM-7539: Change Python docstring before/after blank space guidelines for consistency with PEP 257 (RFC-218)

### DIFF
--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -199,6 +199,10 @@ Style changes must be encapsulated in a distinct commit (see :ref:`git-commit-or
 2. Layout
 =========
 
+.. seealso::
+
+   :doc:`../docs/py_docs` provides guidelines for the :ref:`layout of docstrings <py-docstring-basics>`.
+
 .. _style-guide-py-line-length:
 
 Line Length MUST be less than or equal to 110 columns
@@ -257,13 +261,6 @@ Instead, the continued line should be indented:
    if (width == 0 and
            height == 0):
        pass
-
-.. _style-guide-py-docstring-blank-lines:
-
-Blank lines SHOULD NOT be added before or after a docstring
------------------------------------------------------------
-
-Do not use a blank line on either side of a docstring.
 
 .. _style-guide-py-cpp-consistency:
 

--- a/docs/py_docs.rst
+++ b/docs/py_docs.rst
@@ -77,12 +77,12 @@ An example of a multi-paragraph docstring:
       Sum of `values`.
    """
 
-.. _py-docstring-no-blanks:
+.. _py-docstring-blank-lines:
 
-Docstrings SHOULD NOT be preceded or followed by a blank line
--------------------------------------------------------------
+Docstrings of methods and functions SHOULD NOT be preceded or followed by a blank line
+--------------------------------------------------------------------------------------
 
-For example:
+Inside a function or method, there should be no blank lines surrounding the docstring.
 
 .. code-block:: py
 
@@ -100,6 +100,29 @@ For example:
           Sum of `values`.
        """
        pass
+
+.. _py-docstring-class-blank-lines:
+
+Docstrings of classes SHOULD be followed, but not preceded, by a blank line
+---------------------------------------------------------------------------
+
+Like method and function docstrings, the docstring should immediately follow the class definition, without a blank space.
+However, there should be a **single blank line before following code** such as class variables or the ``__init__`` method.
+
+.. code-block:: py
+
+   class Point(object):
+       """Point in a 2D cartesian space.
+
+       Parameters
+       ----------
+       x, y : `float`
+          Coordinate of the point.
+       """
+
+       def __init__(x, y):
+           self.x = x
+           self.y = y
 
 .. _py-docstring-indentation:
 

--- a/docs/py_docs.rst
+++ b/docs/py_docs.rst
@@ -92,7 +92,7 @@ For example:
        Parameters
        ----------
        values : iterable
-          Python interable whose values are summed.
+          Python iterable whose values are summed.
 
        Returns
        -------
@@ -116,7 +116,7 @@ For example:
        Parameters
        ----------
        values : iterable
-          Python interable whose values are summed.
+          Python iterable whose values are summed.
        """
        pass
 
@@ -130,7 +130,7 @@ Not:
    Parameters
    ----------
    values : iterable
-      Python interable whose values are summed.
+      Python iterable whose values are summed.
    """
        pass
 


### PR DESCRIPTION
- Consolidates all docstring layout advice into the 'Documenting Python APIs' page. This is a change-controlled extension of the Python Style Guide.
- Distinguish between preceding/following blank space guidelines for PEP 257 consistency. Docstrings for classes are **followed** by a blank line.