### PR TITLE
DM-7568: Fix link in C++ Style Guide to using devtoolset-3

### DIFF
--- a/coding/cpp_style_guide.rst
+++ b/coding/cpp_style_guide.rst
@@ -2532,12 +2532,11 @@ They may be used in ``.h`` interface header files if:
 - the usage is hidden from SWIG, either because they are not in method signatures or because they have been explicitly excluded with ``#ifndef`` SWIG, or
 - SWIG has been empirically shown to work with the code (e.g. by successful buildbot run with appropriate Python-based test cases).
 
-See also
---------
+.. seealso::
 
-Instructions for using devtoolset-3 to obtain a more modern gcc on the LSST cluster machines: https://confluence.lsstcorp.org/display/LDMDG/Developer+Tools+at+NCSA#DeveloperToolsatNCSA-AlternateDevelopmentEnvironment.
-
-C++11 compiler support matrix: http://wiki.apache.org/stdcxx/C++0xCompilerSupport.
+   - :ref:`pipelines:source-install-redhat-legacy` from the `LSST Science Pipelines <https://pipelines.lsst.io>`__ documentation.
+   - :doc:`../services/lsst-dev` provides :ref:`instructions for using devtoolset-3 <lsst-dev-tools>` to obtain a more modern GCC on LSST cluster machines.
+   - C++11 compiler support matrix: http://wiki.apache.org/stdcxx/C++0xCompilerSupport.
 
 .. _style-guide-cpp-using:
 

--- a/conf.py
+++ b/conf.py
@@ -378,11 +378,12 @@ epub_exclude_files = ['search.html']
 # If false, no index is generated.
 # epub_use_index = True
 
-
-# Example configuration for intersphinx: refer to the Python standard library.
+# Intersphinx configuration.
+# http://www.sphinx-doc.org/en/stable/ext/intersphinx.html
 intersphinx_mapping = {
     'python': ('https://docs.python.org/2.7', None),
     'astropy': ('http://docs.astropy.org/en/stable/', None),
     'numpy': ('http://docs.scipy.org/doc/numpy/', None),
     'pytest': ('http://pytest.org/latest', None),
+    'pipelines': ('https://pipelines.lsst.io', None)
 }


### PR DESCRIPTION
- The original page on confluence was deprecated by
  services/lsst-dev.rst
- Reformatted as a nice seealso block for clarity.