### PR TITLE
Added setup script example for csh shells.

### DIFF
--- a/build-ci/lsstsw.rst
+++ b/build-ci/lsstsw.rst
@@ -43,6 +43,14 @@ example::
     export EUPS_PATH=$LSSTSW/stack
     . $LSSTSW/bin/setup.sh
 
+.. DO NOT use double quotes in examples -- it activates syntax highlighting
+
+::
+
+    setenv LSSTSW <where you've set it up>
+    setenv EUPS_PATH $LSSTSW/stack
+    source $LSSTSW/bin/setup.csh
+
 .. note::
 
    It is only necessary to run :command:`deploy` once, although it is clever


### PR DESCRIPTION
Having a bash and a csh example present should be sufficient, given
that `deploy` provides interactive instructions as well.