### PR TITLE
DM-7674: Update Community category onboarding

### DIFF
--- a/getting-started/onboarding.rst
+++ b/getting-started/onboarding.rst
@@ -9,54 +9,73 @@ Accounts
 ========
 
 LSST account
-   Contact ``lsst-sysadmins _at_ lsst.org`` to get a unified LSST account.
-   This gives you access to:
+------------
 
-   - The internal project website, including travel requests: http://project.lsst.org
-   - The JIRA project management app: http://jira.lsstcorp.org/
-   - The Confluence wiki: https://confluence.lsstcorp.org
+Contact ``lsst-sysadmins _at_ lsst.org`` to get a unified LSST account.
+This gives you access to:
+
+- The internal project website, including travel requests: http://project.lsst.org
+- The JIRA project management app: http://jira.lsstcorp.org/
+- The Confluence wiki: https://confluence.lsstcorp.org
 
 GitHub and LSST organizations
-   If you don't have one already, create an account on https://github.org.
-   Also see the :doc:`/tools/git_setup` page for recommendations on setting up two-factor authentication and credential helpers for GitHub.
+-----------------------------
 
-   Next, ask your T/CAM to add you to the `lsst <https://github.com/lsst>`__ and `lsst-dm <https://github.com/lsst>`__ GitHub organizations, along with any relevant team organizations (send your GitHub username to your T/CAM).
+If you don't have one already, create an account on https://github.com.
+
+Next, ask your T/CAM to add you to the `lsst <https://github.com/lsst>`__ and `lsst-dm <https://github.com/lsst>`__ GitHub organizations, along with any relevant team organizations (send your GitHub username to your T/CAM).
+   
+.. seealso::
+
+   - :doc:`/tools/git_setup` page for recommendations on setting up two-factor authentication and credential helpers for GitHub.
+   - :doc:`/tools/git_lfs` page for configuring Git LFS for DM.
 
 NCSA server access
-   Contact ``lsst-account _at_ ncsa.illinois.edu`` to request an account on the NCSA cluster, which hosts the reference platform. Include the following in the request:
+------------------
 
-   - First and last name
-   - Email
-   - Phone number
-   - Mailing address
-   - Sponsoring LSST manager
-   - LSST Team or project
+Contact ``lsst-account _at_ ncsa.illinois.edu`` to request an account on the NCSA cluster, which hosts the reference platform.
+Include the following in the request:
 
-   Also see: :doc:`/services/lsst-dev`.
+- First and last name
+- Email
+- Phone number
+- Mailing address
+- Sponsoring LSST manager
+- LSST Team or project
+
+.. seealso::
+
+   :doc:`/services/lsst-dev`.
 
 Community.lsst.org
-   https://community.lsst.org is LSST's public-facing discussion and support forum.
-   Browse the `forum-howto <https://community.lsst.org/tags/forum-howto>`_ tag to learn how to use the platform.
+------------------
+
+https://community.lsst.org is LSST's public-facing discussion and support forum.
+Browse the `forum-howto <https://community.lsst.org/tags/forum-howto>`_ tag to learn how to use the platform.
    
-   Create an account, and let your T/CAM know your username to get access to internal discussion categories.
+Create an account, and let your T/CAM know your username to get access to internal discussion categories.
    
-   T/CAMs: add users via the `LSST <https://community.lsst.org/groups/LSST>`__ and `LSSTDM <https://community.lsst.org/groups/LSSTDM>`__ group pages.
+**T/CAMs:** add users via the `LSST <https://community.lsst.org/groups/LSST>`__ and `LSSTDM <https://community.lsst.org/groups/LSSTDM>`__ group pages.
    
 
 HipChat
-   `HipChat <https://www.hipchat.com/>`_ is DM's internal instant messaging platform.
-   Install HipChat on your computer (and phone, if you wish) and then ask your T/CAM for an invitation to DM's group.
-   Some important rooms to follow are:
+-------
+
+`HipChat <https://www.hipchat.com/>`_ is DM's internal instant messaging platform.
+Install HipChat on your computer (and phone, if you wish) and then ask your T/CAM for an invitation to DM's group.
+Some important rooms to follow are:
    
-   - 'Data Management' for general DM discussion,
-   - 'Software Development' for anything about writing software,
-   - 'SQuaRE' for developer support services,
-   - 'Bot: Jenkins' for our Continuous Integration system,
-   - 'Tavern' for "water cooler" type talk,
-   - 'Tea Time' for more serious but still non-LSST conversation
+- 'Data Management' for general DM discussion.
+- 'Software Development' for anything about writing software.
+- 'SQuaRE' for developer support services.
+- 'Bot: Jenkins' for our Continuous Integration system.
+- 'Tavern' for "water cooler" type talk.
+- 'Tea Time' for more serious but still non-LSST conversation.
    
-   Your team may also have specific rooms, and you can send private messages to individuals.
+Your team may also have specific rooms, and you can send private messages to individuals.
 
 Google account for Hangouts
-   Many small meetings are conducted on `Google Hangouts <https://hangouts.google.com/>`_, which requires you to have an account with https://google.com.
-   The meeting convener will pass around a Hangouts room URL to attendees.
+---------------------------
+
+Many small meetings are conducted on `Google Hangouts <https://hangouts.google.com/>`_, which requires you to have an account with https://google.com.
+The meeting convener will pass around a Hangouts room URL to attendees.

--- a/getting-started/onboarding.rst
+++ b/getting-started/onboarding.rst
@@ -3,15 +3,12 @@ Developer Onboarding Checklist
 ##############################
 
 *Welcome to Data Management*.
-This page will help you get the necessary accounts and point you to important resources and documentation.
-
-Accounts
-========
+This page will help you get the necessary accounts.
 
 .. _getting-started-lsst-account:
 
 LSST account
-------------
+============
 
 Contact ``lsst-sysadmins _at_ lsst.org`` to get a unified LSST account.
 This gives you access to:
@@ -21,7 +18,7 @@ This gives you access to:
 - The Confluence wiki: https://confluence.lsstcorp.org
 
 GitHub and LSST organizations
------------------------------
+=============================
 
 If you don't have one already, create an account on https://github.com.
 
@@ -33,7 +30,7 @@ Next, ask your T/CAM to add you to the `lsst <https://github.com/lsst>`__ and `l
    - :doc:`/tools/git_lfs` page for configuring Git LFS for DM.
 
 NCSA server access
-------------------
+==================
 
 Contact ``lsst-account _at_ ncsa.illinois.edu`` to request an account on the NCSA cluster, which hosts the reference platform.
 Include the following in the request:
@@ -50,7 +47,7 @@ Include the following in the request:
    :doc:`/services/lsst-dev`.
 
 Community.lsst.org
-------------------
+==================
 
 https://community.lsst.org is LSST's public-facing discussion and support forum.
 Browse the `forum-howto <https://community.lsst.org/tags/forum-howto>`_ tag to learn how to use the platform.
@@ -61,7 +58,7 @@ Create an account, and let your T/CAM know your username to get access to intern
    
 
 HipChat
--------
+=======
 
 `HipChat <https://www.hipchat.com/>`_ is DM's internal instant messaging platform.
 Install HipChat on your computer (and phone, if you wish) and then ask your T/CAM for an invitation to DM's group.
@@ -77,13 +74,13 @@ Some important rooms to follow are:
 Your team may also have specific rooms, and you can send private messages to individuals.
 
 Google account for Hangouts
----------------------------
+===========================
 
 Many small meetings are conducted on `Google Hangouts <https://hangouts.google.com/>`_, which requires you to have an account with https://google.com.
 The meeting convener will pass around a Hangouts room URL to attendees.
 
 Mailing lists
--------------
+=============
 
 We don't use mailing lists for conversations, but they're still used for notifications about conversations happening on https://community.lsst.org.
 You should be subscribed to these lists as soon as you get an :ref:`LSST acccount <getting-started-lsst-account>`:

--- a/getting-started/onboarding.rst
+++ b/getting-started/onboarding.rst
@@ -20,7 +20,7 @@ GitHub and LSST organizations
    If you don't have one already, create an account on https://github.org.
    Also see the :doc:`/tools/git_setup` page for recommendations on setting up two-factor authentication and credential helpers for GitHub.
 
-   Next, ask your T/CAM to add you to the `lsst GitHub organization <https://github.com/lsst>`_ along with any relevant team organizations (send your GitHub username to your T/CAM).
+   Next, ask your T/CAM to add you to the `lsst <https://github.com/lsst>`__ and `lsst-dm <https://github.com/lsst>`__ GitHub organizations, along with any relevant team organizations (send your GitHub username to your T/CAM).
 
 NCSA server access
    Contact ``lsst-account _at_ ncsa.illinois.edu`` to request an account on the NCSA cluster, which hosts the reference platform. Include the following in the request:
@@ -36,8 +36,12 @@ NCSA server access
 
 Community.lsst.org
    https://community.lsst.org is LSST's public-facing discussion and support forum.
-   Create an account there, and let your T/CAM know your username so you can be added to the ``LSST`` and ``LSSTDM`` groups.
    Browse the `forum-howto <https://community.lsst.org/tags/forum-howto>`_ tag to learn how to use the platform.
+   
+   Create an account, and let your T/CAM know your username to get access to internal discussion categories.
+   
+   T/CAMs: add users via the `LSST <https://community.lsst.org/groups/LSST>`__ and `LSSTDM <https://community.lsst.org/groups/LSSTDM>`__ group pages.
+   
 
 HipChat
    `HipChat <https://www.hipchat.com/>`_ is DM's internal instant messaging platform.

--- a/getting-started/onboarding.rst
+++ b/getting-started/onboarding.rst
@@ -8,6 +8,8 @@ This page will help you get the necessary accounts and point you to important re
 Accounts
 ========
 
+.. _getting-started-lsst-account:
+
 LSST account
 ------------
 
@@ -79,3 +81,12 @@ Google account for Hangouts
 
 Many small meetings are conducted on `Google Hangouts <https://hangouts.google.com/>`_, which requires you to have an account with https://google.com.
 The meeting convener will pass around a Hangouts room URL to attendees.
+
+Mailing lists
+-------------
+
+We don't use mailing lists for conversations, but they're still used for notifications about conversations happening on https://community.lsst.org.
+You should be subscribed to these lists as soon as you get an :ref:`LSST acccount <getting-started-lsst-account>`:
+
+- `dm-devel <https://lists.lsst.org/mailman/listinfo/dm-devel>`_
+- `dm-staff <https://lists.lsst.org/mailman/listinfo/dm-staff>`_ (internal list)


### PR DESCRIPTION
- T/CAMs now onboard team members in community categories using the group page, not the admin interface.
- Reformat from definition list to sections

https://developer.lsst.io/v/DM-7674/getting-started/onboarding.html