### PR TITLE
DM-8586: Policies for presentations and publications

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -35,6 +35,7 @@ The `README <https://github.com/lsst-dm/dm_dev_guide/blob/master/README.md>`__ w
    processes/jira_agile.rst
    processes/wiki.rst
    processes/presenting-at-conferences.rst
+   processes/publication-policy.rst
 
 .. seealso::
 

--- a/index.rst
+++ b/index.rst
@@ -34,6 +34,7 @@ The `README <https://github.com/lsst-dm/dm_dev_guide/blob/master/README.md>`__ w
    processes/project_planning.rst
    processes/jira_agile.rst
    processes/wiki.rst
+   processes/presenting-at-conferences.rst
 
 .. seealso::
 

--- a/processes/presenting-at-conferences.rst
+++ b/processes/presenting-at-conferences.rst
@@ -4,6 +4,11 @@ Presenting at Conferences
 
 This is our playbook for presenting on behalf of DM at both project and public meetings.
 
+.. seealso::
+
+   Conference proceedings papers are coordinated by the LSST Project Publication Board.
+   See :doc:`publication-policy` for more information.
+
 .. _presenting-interaction-report:
 
 Interaction report

--- a/processes/presenting-at-conferences.rst
+++ b/processes/presenting-at-conferences.rst
@@ -1,0 +1,149 @@
+#########################
+Presenting at Conferences
+#########################
+
+This is our playbook for presenting on behalf of DM at both project and public meetings.
+
+.. _presenting-interaction-report:
+
+Interaction report
+==================
+
+As DM team members, we work within an NSF and DOE funded MREFC construction project.
+It's important that we're consistent with the Project when we speak in public and with government officials.
+As you're preparing your presentation:
+
+- `File an interaction report <https://project.lsst.org/interactions>`__. Interaction reports are required when presenting at a public meeting or with government officials.
+- Use and refer to the Project's `pre-approved material <https://project.lsst.org/preapproved>`__ for presentations, including schedule information.
+- Use the Project's `Key Numbers <https://confluence.lsstcorp.org/display/LKB/LSST+Key+Numbers>`__.
+
+.. _presenting-templates:
+
+Slide templates and stock
+=========================
+
+If the meeting doesn't have a specific slide template, use the `Project's templates and stock slides <https://project.lsst.org/documents/stock-slides-templates>`__.
+
+The Project `image and video gallery <https://www.lsst.org/gallery/image-gallery>`__ is also an excellent source of content.
+
+.. _presenting-slack:
+
+Slack during the meeting
+========================
+
+You might want to create a dedicated Slack channel for the meeting you're attending.
+Use this channel to coordinate with other on-site LSST folks and to live-blog for the rest of the team.
+Here's how to make the channel:
+
+1. `Create a channel <https://get.slack.help/hc/en-us/articles/201402297-Create-a-channel>`__ on https://lsstc.slack.com. Use a ``meetings-`` prefix for the channel name.
+   For example: ``meetings-adass-2016``.
+2. Announce the channel in `#lsst-newchannels <https://lsstc.slack.com/archives/lsst-newchannels>`__.
+   You might want to also mention the channel in `#dm <https://lsstc.slack.com/archives/dm>`__ since `#lsst-newchannels <https://lsstc.slack.com/archives/lsst-newchannels>`__ is lightly followed.
+
+.. _presenting-report:
+
+Summarize the meeting on the Community forum
+============================================
+
+Once the meeting is over, it's a great idea to write down what happened.
+This record helps the rest of the team benefit from your experience.
+
+Write your summary as a new topic in the `LSST Project <https://community.lsst.org/c/lsst-project>`__ category on the Community forum.
+If multiple team members attended the same meeting, you can either collate your post beforehand, or post multiple replies within the same topic thread.
+
+Tag your topic with ‘`conference-report <http://community.lsst.org/tags/conference-report>`_\ ’ so it's easy to find later.
+
+.. note::
+
+   The `LSST Project <https://community.lsst.org/c/lsst-project>`__ forum category is only visible to LSST staff (including DM, but other Project subsystems too).
+   This venue gives you license to frankly assess reaction from the community to LSST and other projects.
+
+.. _presenting-zenodo:
+
+Upload slides to the LSST DM Zenodo Community
+=============================================
+
+.. https://zenodo.org/deposit/new?c=lsst-dm
+.. Upload PDF and source (keynote or powerpoint version)
+
+DM collects conference material (slide decks, in particular) in the `Large Synoptic Survey Telescope Data Management community on Zenodo <https://zenodo.org/communities/lsst-dm/>`__.
+Zenodo archives and provides Digital Object Identifiers (DOIs) for scientific artifacts.
+DOIs let you to robustly cite artifacts in scientific literature.
+
+Uploading your material to Zenodo is a self-service process.
+The instructions below will get you started.
+
+.. _presenting-zenodo-upload:
+
+Zenodo submission procedure
+---------------------------
+
+If you haven't already, create an account at https://zenodo.org.
+You might want to login with your existing `GitHub <https://github.com>`__ or `ORCiD <http://orcid.org>`__ accounts.
+
+To start your upload, go to this dedicated page for LSST DM: https://zenodo.org/deposit/new?c=lsst-dm.
+
+Next, fill out each relevant section of the submission page:
+
+- **Files.** For presentations, include both the original source files (such as PowerPoint or Keynote documents) **and** an exported PDF version.
+
+- **Upload type.** Typically choose **Presentation** for conference presentation material. If you have multiple types of artifacts from the same event (such as a slide deck, a video of your presentation, and a proceedings paper) it's best to submit each separately. Reach out to `#dm-docs <https://lsstc.slack.com/archives/dm-docs>`__ for advice.
+
+- **Basic information.**
+
+  - **Digital Object Identifier.** Usually you'll leave this blank. But if you want to include the DOI in your archived slide deck: click the 'Pre-Reserve DOI' button, add the reserved DOI to your artifacts, and then upload those artifacts.
+
+  - **Publication date.** This is the day you presented or otherwise 'published' the material, not necessarily today's date.
+
+  - **Title.** This should match your presentation's title in the meeting's agenda.
+
+  - **Authors.**
+
+  - **Description.** Use the abstract for your presentation. Don't include metadata about the conference here.
+
+  - **Keywords.** Include ``lsst`` and any other keywords you see fit.
+
+- **License.** Choose **Open Access** and the **Creative Commons Attribution 4.0** license unless you have extenuating circumstances. Reach out to `#dm-docs <https://lsstc.slack.com/archives/dm-docs>`__ for advice.
+
+- **Communities.** Ensure that **Large Synoptic Survey Telescope Data Management** is included here (it's added by default by using the `DM upload page <https://zenodo.org/deposit/new?c=lsst-dm>`__). Your meeting might have also have a Zenodo community that you should add.
+
+- **Related/alternate identifiers.** This is an optional section where you can connect your upload to other artifacts. For example, if the proceedings paper is on `arXiv.org <https://arxiv.org>`__, you could provide the arXiv ID and say it "is a supplement to this upload." Use as many related identifiers as necessary. Again, reach out to `#dm-docs <https://lsstc.slack.com/archives/dm-docs>`__ for advice.
+
+- **References.** You might choose to provide your reference list here, but it's not necessary.
+
+- **Conference.** Include as much metadata about the conference or meeting as possible.
+
+  - **Conference title.** Example: ``Astronomical Data Analysis Software and Systems XXVI``.
+
+  - **Acronym.** Example: ``ADASS XXVI``.
+
+  - **Dates.**
+
+  - **Place.**
+
+  - **Website.** Use the website of the meeting, not necessarily the organization. For example, use http://www.adass2016.inaf.it/index.php rather than http://www.adass.org.
+
+  - **Session.**
+
+  - **Part.**
+
+Once all the metadata is filled in, click **Save** *and then* click **Publish.** In a moment, the DM community moderator will approve your submission and it'll appear at https://zenodo.org/communities/lsst-dm/.
+
+.. note::
+
+   You can always update metadata for your uploads by visiting https://zenodo.org/deposit.
+   Also, keep in mind that *only you* can maintain the metadata for your uploads.
+   If there's an issue, someone from DM may ask you to change a metadata field.
+   However, you *can't* change the uploaded artifact itself.
+
+.. _presenting-zenodo-sharing:
+
+Sharing your work
+-----------------
+
+Now that your presentation is durably archived you can share it widely:
+
+- Add the URL of your presentation's Zenodo page to your :ref:`Community conference report <presenting-report>`.
+  Discourse will helpfully embed a preview of your slides.
+- Tweet the URL of your presentation's Zenodo page.
+- Export a BibTeX citation for your slides from the presentation's Zenodo page.

--- a/processes/presenting-at-conferences.rst
+++ b/processes/presenting-at-conferences.rst
@@ -94,15 +94,23 @@ Also add a link to your meeting report to https://confluence.lsstcorp.org/displa
    The `LSST Project <https://community.lsst.org/c/lsst-project>`__ forum category is only visible to LSST staff (including DM, but other Project subsystems too).
    This venue gives you license to frankly assess reaction from the community to LSST and other projects.
 
+.. _presenting-proceedings:
+
+Submit proceedings papers (required)
+====================================
+
+If you are writing a proceedings paper in conjunction with your presentation, you'll need to submit it to the LSST Publication Board before submitting it to the publisher.
+See :doc:`publication-policy` for details.
+
+After Publication Board approval, proceedings papers should be submitted to https://arXiv.org if the agreement with the publisher allows.
+*We don't use Zenodo for proceedings.*
+
 .. _presenting-zenodo:
 
-Upload slides to the LSST DM Zenodo Community (required)
-========================================================
+Upload slides and posters to the LSST DM Zenodo Community (required)
+====================================================================
 
-.. https://zenodo.org/deposit/new?c=lsst-dm
-.. Upload PDF and source (keynote or powerpoint version)
-
-DM collects conference material (slide decks, in particular) in the `Large Synoptic Survey Telescope Data Management community on Zenodo <https://zenodo.org/communities/lsst-dm/>`__.
+DM collects conference presentation material (slide decks and posters, but **not** proceedings) in the `Large Synoptic Survey Telescope Data Management community on Zenodo <https://zenodo.org/communities/lsst-dm/>`__.
 Zenodo archives and provides Digital Object Identifiers (DOIs) for scientific artifacts.
 DOIs let you to robustly cite artifacts in scientific literature.
 
@@ -115,7 +123,7 @@ Zenodo submission procedure
 ---------------------------
 
 If you haven't already, create an account at https://zenodo.org.
-You might want to login with your existing `GitHub <https://github.com>`__ or `ORCiD <http://orcid.org>`__ accounts.
+You might want to log in with your existing `GitHub <https://github.com>`__ or `ORCiD <http://orcid.org>`__ accounts.
 
 To start your upload, go to this dedicated page for LSST DM: https://zenodo.org/deposit/new?c=lsst-dm.
 
@@ -123,7 +131,7 @@ Next, fill out each relevant section of the submission page:
 
 - **Files.** For presentations, include both the original source files (such as PowerPoint or Keynote documents) **and** an exported PDF version.
 
-- **Upload type.** Typically choose **Presentation** for conference presentation material. If you have multiple types of artifacts from the same event (such as a slide deck, a video of your presentation, and a proceedings paper) it's best to submit each separately. Reach out to `#dm-docs <https://lsstc.slack.com/archives/dm-docs>`__ for advice.
+- **Upload type.** Typically choose **Presentation** or **Poster** for conference presentation material. If you have multiple types of artifacts from the same event it's best to submit each separately. Reach out to `#dm-docs <https://lsstc.slack.com/archives/dm-docs>`__ for advice.
 
 - **Basic information.**
 
@@ -143,7 +151,7 @@ Next, fill out each relevant section of the submission page:
 
 - **Communities.** Ensure that **Large Synoptic Survey Telescope Data Management** is included here (it's added by default by using the `DM upload page <https://zenodo.org/deposit/new?c=lsst-dm>`__). Your meeting might have also have a Zenodo community that you should add.
 
-- **Related/alternate identifiers.** This is an optional section where you can connect your upload to other artifacts. For example, if the proceedings paper is on `arXiv.org <https://arxiv.org>`__, you could provide the arXiv ID and say it "is a supplement to this upload." Use as many related identifiers as necessary. Again, reach out to `#dm-docs <https://lsstc.slack.com/archives/dm-docs>`__ for advice.
+- **Related/alternate identifiers.** This is an optional section where you can connect your upload to other artifacts. For example, if presentation you're uploading to Zenodo is associated with a proceedings paper on `arXiv.org <https://arxiv.org>`__, you could provide the arXiv ID and say it "is a supplement to this upload." Use as many related identifiers as necessary. Again, reach out to `#dm-docs <https://lsstc.slack.com/archives/dm-docs>`__ for advice.
 
 - **References.** You might choose to provide your reference list here, but it's not necessary.
 

--- a/processes/presenting-at-conferences.rst
+++ b/processes/presenting-at-conferences.rst
@@ -9,6 +9,32 @@ This is our playbook for presenting on behalf of DM at both project and public m
    Conference proceedings papers are coordinated by the LSST Project Publication Board.
    See :doc:`publication-policy` for more information.
 
+.. _presenting-confluence-meeting-page:
+
+Sign up for a meeting on Confluence (required)
+==============================================
+
+DM tracks meetings, along with who will attend them, at https://confluence.lsstcorp.org/display/DM/DM+Meetings.
+
+If you're interesting in attending a meeting, add your name to the column "Expressed Interest in Attending."
+
+Once your travel is approved (see :ref:`Travel requests <presenting-travel-requests>`), move your name to the "Attending" column.
+
+*This is a required step.*
+
+.. _presenting-travel-requests:
+
+Travel requests (required)
+==========================
+
+You'll need to fill out a *travel request* (TR) to travel to a meeting.
+The TR both lets the project approve the expense and puts the Project travel coordinator to work on booking your itinerary.
+Instructions for submitting TRs are at https://project.lsst.org/travel/travel-requests.
+
+After your trip, you'll need to also fill out a *travel expense report* (TER). Instructions for filing TERs are at https://project.lsst.org/travel/reimbursement.
+
+*These are required steps.*
+
 .. _presenting-interaction-report:
 
 Interaction report
@@ -57,6 +83,8 @@ Write your summary as a new topic in the `LSST Project <https://community.lsst.o
 If multiple team members attended the same meeting, you can either collate your post beforehand, or post multiple replies within the same topic thread.
 
 Tag your topic with ‘`conference-report <http://community.lsst.org/tags/conference-report>`_\ ’ so it's easy to find later.
+
+Also add a link to your meeting report to https://confluence.lsstcorp.org/display/DM/DM+Meetings.
 
 .. note::
 
@@ -142,6 +170,11 @@ Once all the metadata is filled in, click **Save** *and then* click **Publish.**
    However, you *can't* change the uploaded artifact itself.
 
 .. _presenting-zenodo-sharing:
+
+Link from the DM Meetings page
+------------------------------
+
+Once your slides are archived, link to them from the DM Meetings page, https://confluence.lsstcorp.org/display/DM/DM+Meetings.
 
 Sharing your work
 -----------------

--- a/processes/presenting-at-conferences.rst
+++ b/processes/presenting-at-conferences.rst
@@ -41,11 +41,13 @@ If the meeting doesn't have a specific slide template, use the `Project's templa
 
 .. _presenting-key-numbers:
 
-Key numbers and stock graphics (as needed)
-==========================================
+Key numbers, pre-approved material, and stock graphics (as needed)
+==================================================================
 
 You must ensure that any LSST performance characteristics you state are consistent with the Project's `Key Numbers`_.
 These numbers are rigorously vetted and maintained.
+
+The Project also maintains a collection of `pre-approved material <https://project.lsst.org/preapproved>`__ for presentations, including project status, schedule, and general background.
 
 If you need visualizations or photos of the telescope, the Project `image and video gallery <https://www.lsst.org/gallery/image-gallery>`__ is also an excellent resource.
 

--- a/processes/presenting-at-conferences.rst
+++ b/processes/presenting-at-conferences.rst
@@ -1,8 +1,8 @@
-#########################
-Presenting at Conferences
-#########################
+#######################################
+Attending and Presenting at Conferences
+#######################################
 
-This is our playbook for presenting on behalf of DM at both project and public meetings.
+This is our playbook for going to Project and public meetings, and presenting on behalf of DM.
 
 .. seealso::
 
@@ -20,8 +20,6 @@ If you're interesting in attending a meeting, add your name to the column "Expre
 
 Once your travel is approved (see :ref:`Travel requests <presenting-travel-requests>`), move your name to the "Attending" column.
 
-*This is a required step.*
-
 .. _presenting-travel-requests:
 
 Travel requests (required)
@@ -31,36 +29,32 @@ You'll need to fill out a *travel request* (TR) to travel to a meeting.
 The TR both lets the project approve the expense and puts the Project travel coordinator to work on booking your itinerary.
 Instructions for submitting TRs are at https://project.lsst.org/travel/travel-requests.
 
-After your trip, you'll need to also fill out a *travel expense report* (TER). Instructions for filing TERs are at https://project.lsst.org/travel/reimbursement.
-
-*These are required steps.*
-
-.. _presenting-interaction-report:
-
-Interaction report
-==================
-
-As DM team members, we work within an NSF and DOE funded MREFC construction project.
-It's important that we're consistent with the Project when we speak in public and with government officials.
-As you're preparing your presentation:
-
-- `File an interaction report <https://project.lsst.org/interactions>`__. Interaction reports are required when presenting at a public meeting or with government officials.
-- Use and refer to the Project's `pre-approved material <https://project.lsst.org/preapproved>`__ for presentations, including schedule information.
-- Use the Project's `Key Numbers <https://confluence.lsstcorp.org/display/LKB/LSST+Key+Numbers>`__.
+After your trip, you'll need to also fill out a *travel expense report* (TER).
+Instructions for filing TERs are at https://project.lsst.org/travel/reimbursement.
 
 .. _presenting-templates:
 
-Slide templates and stock
-=========================
+Slide templates (required)
+==========================
 
 If the meeting doesn't have a specific slide template, use the `Project's templates and stock slides <https://project.lsst.org/documents/stock-slides-templates>`__.
 
-The Project `image and video gallery <https://www.lsst.org/gallery/image-gallery>`__ is also an excellent source of content.
+.. _presenting-key-numbers:
+
+Key numbers and stock graphics (as needed)
+==========================================
+
+You must ensure that any LSST performance characteristics you state are consistent with the Project's `Key Numbers`_.
+These numbers are rigorously vetted and maintained.
+
+If you need visualizations or photos of the telescope, the Project `image and video gallery <https://www.lsst.org/gallery/image-gallery>`__ is also an excellent resource.
+
+.. _Key Numbers: https://confluence.lsstcorp.org/display/LKB/LSST+Key+Numbers
 
 .. _presenting-slack:
 
-Slack during the meeting
-========================
+Slack during the meeting (optional)
+===================================
 
 You might want to create a dedicated Slack channel for the meeting you're attending.
 Use this channel to coordinate with other on-site LSST folks and to live-blog for the rest of the team.
@@ -73,11 +67,20 @@ Here's how to make the channel:
 
 .. _presenting-report:
 
-Summarize the meeting on the Community forum
-============================================
+Summarize the meeting on the Community forum (by request)
+=========================================================
 
 Once the meeting is over, it's a great idea to write down what happened.
 This record helps the rest of the team benefit from your experience.
+
+Policy on requesting a summary
+------------------------------
+
+Conference summaries are a great idea, but you're not required to write one.
+DM team members can ask each other to write summaries of their meeting experience by writing a JIRA ticket and assigning it to the attendee.
+
+How to write the summary
+------------------------
 
 Write your summary as a new topic in the `LSST Project <https://community.lsst.org/c/lsst-project>`__ category on the Community forum.
 If multiple team members attended the same meeting, you can either collate your post beforehand, or post multiple replies within the same topic thread.
@@ -93,8 +96,8 @@ Also add a link to your meeting report to https://confluence.lsstcorp.org/displa
 
 .. _presenting-zenodo:
 
-Upload slides to the LSST DM Zenodo Community
-=============================================
+Upload slides to the LSST DM Zenodo Community (required)
+========================================================
 
 .. https://zenodo.org/deposit/new?c=lsst-dm
 .. Upload PDF and source (keynote or powerpoint version)
@@ -171,15 +174,15 @@ Once all the metadata is filled in, click **Save** *and then* click **Publish.**
 
 .. _presenting-zenodo-sharing:
 
-Link from the DM Meetings page
-------------------------------
+Link from the DM Meetings page (required)
+-----------------------------------------
 
 Once your slides are archived, link to them from the DM Meetings page, https://confluence.lsstcorp.org/display/DM/DM+Meetings.
 
-Sharing your work
------------------
+Sharing your work (optional)
+----------------------------
 
-Now that your presentation is durably archived you can share it widely:
+Some ideas:
 
 - Add the URL of your presentation's Zenodo page to your :ref:`Community conference report <presenting-report>`.
   Discourse will helpfully embed a preview of your slides.

--- a/processes/publication-policy.rst
+++ b/processes/publication-policy.rst
@@ -1,3 +1,5 @@
+.. _publication-policy:
+
 #################################
 Publishing Papers and Proceedings
 #################################

--- a/processes/publication-policy.rst
+++ b/processes/publication-policy.rst
@@ -1,0 +1,33 @@
+#################################
+Publishing Papers and Proceedings
+#################################
+
+Papers and conference proceedings written on behalf of the LSST Project are subject to the LSST Project Publication Policy (:lpm:`162`) and are coordinated by the Publication Board.
+This page provides pointers to Publication Board documentation.
+
+.. note::
+
+   While scientific publications and conference proceedings are subject to :lpm:`162`, many types of DM communication and documentation are not controlled, including:
+
+   - User guides (software documentation).
+   - Technical notes.
+   - Design documentation (though LDMs are coordinated by the DM Technical Control Team, TCT).
+   - Community forum posts.
+
+Links
+=====
+
+- `Publication Board homepage <https://project.lsst.org/documents/publication-board>`__.
+- `LPM-162: LSST Project Publication Policy <https://www.lsstcorp.org/docushare/dsweb/Get/LPM-162/>`__.
+- `Publication Board JIRA Project (PUB) <https://jira.lsstcorp.org/browse/PUB>`__.
+- `Document-13016: Project Publications Style Manual <https://docushare.lsstcorp.org/docushare/dsweb/Get/Document-13016/LSSTStyleManual.pdf>`__.
+- `lsst-pst/LSSTreferences <https://github.com/lsst-pst/LSSTreferences>`__ GitHub project with citations for key LSST papers.
+
+Citing DM Technical Notes
+=========================
+
+Wherever possible, cite DM design documentation and technotes in addition to the core project papers.
+Rather than linking to the technote's URL in a footnote, you should use a proper citation to the technote's DOI in BibTeX.
+The documentation engineering team is making DOIs on an as-needed basis at the moment.
+Reach out to `#dm-docs <https://lsstc.slack.com/archives/dm-docs>`__ for additional DOIs.
+We're working on automating DOI provisioning to make this easier in the future.

--- a/processes/publication-policy.rst
+++ b/processes/publication-policy.rst
@@ -25,11 +25,57 @@ Links
 - `Document-13016: Project Publications Style Manual <https://docushare.lsstcorp.org/docushare/dsweb/Get/Document-13016/LSSTStyleManual.pdf>`__.
 - `lsst-pst/LSSTreferences <https://github.com/lsst-pst/LSSTreferences>`__ GitHub project with citations for key LSST papers.
 
-Citing DM Technical Notes
-=========================
+Citing DM Technical Notes and Design Documents
+==============================================
 
 Wherever possible, cite DM design documentation and technotes in addition to the core project papers.
-Rather than linking to the technote's URL in a footnote, you should use a proper citation to the technote's DOI in BibTeX.
+Rather than linking to the document's URL in a footnote, you should use a proper BibTeX citation.
+
+For technotes, it's better to cite the technote's DOI than its lsst.io URL alone.
 The documentation engineering team is making DOIs on an as-needed basis at the moment.
 Reach out to `#dm-docs <https://lsstc.slack.com/archives/dm-docs>`__ for additional DOIs.
 We're working on automating DOI provisioning to make this easier in the future.
+
+Example design document citation
+--------------------------------
+
+A BibTeX citation for a design document:
+
+.. code-block:: text
+
+   @misc{LDM-135,
+     author       = {Jacek Becla and others},
+     title        = {{LSST Database Design}},
+     howpublished = {LDM-135, \url{http://ls.st/LDM-135}},
+     year         = 2013,
+   }
+
+Note that the ``ls.st`` short link points to the official DocuShare-archived version of LDM-135.
+
+Example technical note citation
+-------------------------------
+
+A technote citation, pointing to a Zenodo-backed DOI:
+
+.. code-block:: text
+
+   @techreport{slater_2016_192828,
+     title        = {{False Positive Rates in the LSST Image 
+                      Differencing Pipeline}},
+     author       = {{Slater}, Colin and
+                     {Jurić}, Mario and
+                     {Ivezić}, Željko and
+                     {Jones}, Lynne},
+     institution  = {{LSST Data Management}},
+     type         = {{LSST Data Management Technical Note}},
+     number       = {{DMTN-006}},
+     month        = mar,
+     year         = 2016,
+     doi          = {10.5281/zenodo.192828},
+     url          = {https://doi.org/10.5281/zenodo.192828}
+   }
+
+.. note::
+
+   Zenodo offers citations using the ``manual``, rather than ``techreport``, BibTeX type for technical reports, but the example above is likely more complete.
+   The publisher, given their BibTeX style file, may have different guidance.


### PR DESCRIPTION
This adds two new pages describing DM's policies and procedures surrounding conference presentations and publications:

- https://developer.lsst.io/v/DM-8586/processes/presenting-at-conferences.html

  - includes information on how to upload presentations to Zenodo.

- https://developer.lsst.io/v/DM-8586/processes/publication-policy.html

  - Links to Publication Board documentation

### TODO

- [x] Add DM meetings page: https://confluence.lsstcorp.org/display/DM/DM+Meetings
- [x] Figure out status of the Speaker's Bureau and Interaction Reports from the Project Office.
- [x] Determine and add requirement/suggestion markers to each section.
- [x] Re-add the "pre-approved materials" link; LSST PO will update this material.
- [x] Indicate that both presentation **and posters** go to Zenodo.
- [x] Document that proceedings papers go to arXiv and pub board, and **do not** go to Zenodo.
- [x] Provide citation examples for LDM docs and DMTN/SQR technotes. See [PUB-39](https://jira.lsstcorp.org/browse/PUB-39) discussion.