### PR TITLE
DM-8605: Remove log configuration in unit test initialization

### DIFF
--- a/coding/python_testing.rst
+++ b/coding/python_testing.rst
@@ -217,14 +217,6 @@ final test suite.
 For the memory test to function properly the :lfunc:`lsst.utils.tests.init()` function must be invoked before any of the tests in the class are executed.
 Since LSST test scripts are required to run properly from the command-line and when called from within `pytest`_, the :lfunc:`~lsst.utils.tests.init()` function has to be in the file twice: once in the :ref:`setup_module <pytest:xunitsetup>` function that is called by `pytest`_ whenever a test module is loaded (`pytest`_ will not use the ``__main__`` code path), and also just before the call to :func:`unittest.main()` call to handle being called with :command:`python`.
 
-Utility initialization
-----------------------
-
-:lfunc:`lsst.utils.tests.init()` does two things: initialize the memory tester as described previously, and initialize :lmod:`lsst.log` by setting up a default configuration that outputs logs to console at :ldata:`lsst.log.INFO` level.
-Customized configuration can be set in each unit test.
-For example, ``lsst.log.setLevel('', lsst.log.TRACE)`` sets the root logger to :ldata:`lsst.log.TRACE` level.
-See :doc:`logging` for more details in logging use.
-
 Unicode
 =======
 


### PR DESCRIPTION
As the current default log configuration is already good,
the hard-coded log configuration in unit test initialization
is removed; DM-7150 is reverted. Update the doc about that.
This reverts commit 32ae0fb386e84aa274708985ae133fae5d246482
and 491caf0f95a6f2f6e15a348be917895a285eb3d8.