### PR TITLE
DM-9256: Fix search with Sphinx 1.5

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -64,7 +64,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'LSST DM Developer Guide'
-copyright = u'2016 AURA/LSST'
+copyright = u'2016-2017 Association of Universities for Research in Astronomy, Inc.'
 author = u'LSST Data Management'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Sphinx>=1.4.1
-sphinx-rtd-theme
+-e git://github.com/snide/sphinx_rtd_theme/@eef98b316b947a9d8854add13cba702f41f00c14#egg=sphinx_rtd_theme
+Sphinx>=1.5.2
 documenteer>=0.1.4


### PR DESCRIPTION
The third-party [sphinx_rtd_theme](https://github.com/snide/sphinx_rtd_theme) needs to be pinned to an unreleased development version in order to get a search fix described in https://github.com/snide/sphinx_rtd_theme/pull/346.

It works: file:///Users/jsick/lsst/dm_dev_guide/_build/html/search.html?q=git&check_keywords=yes&area=default

