### PR TITLE
DM-8980: Revise Python Style Guide for RFC-107 (79 character line lengths)

### DIFF
--- a/python/numpydoc.rst
+++ b/python/numpydoc.rst
@@ -266,12 +266,7 @@ For example:
 Line Lengths
 ------------
 
-Hard-wrap text in docstrings to match the :ref:`line length allowed by the coding standard <style-guide-py-line-length>`.
-
-.. note::
-
-   In the future we may require shorter line lengths specifically for docstrings.
-   See :jira:`RFC-107`.
+Hard-wrap text in docstrings to match the :ref:`docstring line length allowed by the coding standard <style-guide-py-docstring-line-length>`.
 
 .. _py-docstring-parameter-markup:
 

--- a/python/style.rst
+++ b/python/style.rst
@@ -232,7 +232,7 @@ Docstring and comment line length MUST be less than or equal to 79 columns
 
 Limit all docstring and comment lines to a maximum of 79 characters.
 
-This differs from the `PEP 8 recommendation of 72 characters <https://www.python.org/dev/peps/pep-0008/#maximum-line-length>`_ and the `numpydoc recommendation of 75 characters <https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_ but is a compromise between these and the code line length limit.
+This differs from the `PEP 8 recommendation of 72 characters <https://www.python.org/dev/peps/pep-0008/#maximum-line-length>`_ and the `numpydoc recommendation of 75 characters <https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_ but maintains readability and compatibility with default terminal widths while providing the maximum space.
 
 .. _style-guide-py-implied-continuation:
 

--- a/python/style.rst
+++ b/python/style.rst
@@ -225,6 +225,15 @@ This conforms to the :doc:`/cpp/style` (see :ref:`4-6 <style-guide-cpp-4-6>`).
 
 This differs from the `PEP 8 recommendation of 79 characters <https://www.python.org/dev/peps/pep-0008/#maximum-line-length>`_.
 
+.. _style-guide-py-docstring-line-length:
+
+Docstring and comment line length MUST be less than or equal to 79 columns
+--------------------------------------------------------------------------
+
+Limit all docstring and comment lines to a maximum of 79 characters.
+
+This differs from the `PEP 8 recommendation of 72 characters <https://www.python.org/dev/peps/pep-0008/#maximum-line-length>`_ and the `numpydoc recommendation of 75 characters <https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_ but is a compromise between these and the code line length limit.
+
 .. _style-guide-py-implied-continuation:
 
 Python's implied continuation inside parens, brackets and braces SHOULD be used for wrapped lines


### PR DESCRIPTION
This ticket modifies the style guide to no longer mention 110-character lines. The changed pages are https://developer.lsst.io/v/DM-8980/coding/python_style_guide.html and https://developer.lsst.io/v/DM-8980/docs/rst_styleguide.html.