### PR TITLE
DM-9815: Remove -W sphinx-build flag b/c of docs.scipy.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ install:
   - pip install -r requirements.txt
   - pip install "ltd-mason>=0.2,<0.3"
 script:
-  - sphinx-build -b html -a -n -W -d _build/doctree . _build/html
+  # TODO Add -W flag (DM-9815)
+  - sphinx-build -b html -a -n -d _build/doctree . _build/html
 after_success:
   - ltd-mason-travis --html-dir _build/html
 env:


### PR DESCRIPTION
The docs.scipy.org outage has been breaking docs builds because the unresolved intersphinx links are warnings that `-W` is turning into errors. This commit temporarily removes that flag while docs.scipy.org is generally unavailable.

See
https://community.lsst.org/t/how-docs-scipy-org-and-intersphinx-affect-your-doc-builds/1717?u=jsick
from a long-term mitigation strategy.