### PR TITLE
Clarify that autopep8 >= 1.2 is required

### DIFF
--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -189,7 +189,7 @@ For example, to import a module without using it (to build a namespace, as in a 
 autopep8 MAY be used to fix PEP 8 compliance
 --------------------------------------------
 
-Many :pep:`8` issues in existing code can be fixed with `autopep8`_:
+Many :pep:`8` issues in existing code can be fixed with `autopep8`_ version 1.2 or newer:
 
 .. code-block:: bash
 


### PR DESCRIPTION
**Draft:** https://developer.lsst.io/v/DM-9509/coding/python_style_guide.html#autopep8-may-be-used-to-fix-pep-8-compliance

Older versions treated whitespace above and below docstrings improperly. See https://jira.lsstcorp.org/browse/DM-9509