### PR TITLE
DM-9966: Recommend that TODO comments link to Jira

### DIFF
--- a/coding/cpp_style_guide.rst
+++ b/coding/cpp_style_guide.rst
@@ -2579,6 +2579,20 @@ This maintains consistency by positioning the comment at the same level as the c
 
 .. _style-guide-cpp-legacy-code:
 
+6-26. To-do comments SHOULD include a Jira issue key
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If the commented code is a workaround for a known issue, this rule makes it easier to find and remove the workaround once the issue has been resolved.
+If the commented code itself is the problem, this rule ensures the issue will be reported on Jira, making it more likely to be fixed in a timely manner.
+
+.. code-block:: cpp
+
+   // TODO: workaround for DM-6789
+
+.. code-block:: cpp
+
+   // TODO: DM-12345 is triggered by this line
+
 7. Legacy Code
 ==============
 

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -423,6 +423,20 @@ Each line of a block comment starts with a ``#`` and a single space (unless it i
 
 Paragraphs inside a block comment are separated by a line containing a single ``#``.
 
+To-do comments SHOULD include a Jira issue key
+----------------------------------------------
+
+If the commented code is a workaround for a known issue, this rule makes it easier to find and remove the workaround once the issue has been resolved.
+If the commented code itself is the problem, this rule ensures the issue will be reported on Jira, making it more likely to be fixed in a timely manner.
+
+.. code-block:: py
+
+   # TODO: workaround for DM-6789
+
+.. code-block:: py
+
+   # TODO: DM-12345 is triggered by this line
+
 .. _style-guide-py-docstrings:
 
 5. Documentation Strings (docstrings)


### PR DESCRIPTION
The ticket provides a brief rationale for centralizing technical debt information in Jira. The examples are taken from RFC-307 comments.

Affected pages:
* https://developer.lsst.io/v/DM-9966/coding/python_style_guide.html
* https://developer.lsst.io/v/DM-9966/coding/cpp_style_guide.html