### PR TITLE
Fix incorrect command line task doc.

### DIFF
--- a/coding/debug.rst
+++ b/coding/debug.rst
@@ -40,7 +40,7 @@ Then you can write your task to optionally enable a display (or whatever) by doi
 
 Refer to the `task documentation <http://doxygen.lsst.codes/stack/doxygen/x_masterDoxyDoc/group___l_s_s_t__task__documentation.html>`_ and look for “debug variables” to discover what debugging options are available for existing ``Task``\s.
 
-In order to load your specific debugging configuration, create a ``debug.py`` in your working directory, and put something like this in it::
+In order to load your specific debugging configuration, create a ``debug.py`` somewhere in your ``PYTHONPATH``, and put something like this in it::
 
    import lsstDebug
    def DebugInfo(name):

--- a/coding/debug.rst
+++ b/coding/debug.rst
@@ -6,6 +6,9 @@ Debugging Tasks with ``lsstDebug``
 
    See also the `Doxygen documentation on lsstDebug <http://doxygen.lsst.codes/stack/doxygen/x_masterDoxyDoc/base_debug.html>`_.
 
+Task Authors
+============
+
 In your ``Task`` code, if you ``import lsstDebug`` then call::
 
    debug = lsstDebug.Info(__name__)
@@ -23,9 +26,8 @@ Thus::
    >>> debug.display
    False
 
-The aim is to customize the behaviour of ``debug`` to meet your particular needs.
-In this, you want to define a function that, when called with ``__name__``, as an argument will provide non-``False`` values for certain combinations of ``__name__`` and attribute.
-Thus, you can do things like::
+The task user will customize the behaviour of ``debug`` to meet his/her particular needs by redefining the ``Info`` function to return an object that returns non-``False`` values for certain combinations of ``__name__`` and attribute.
+With this in place, the code above produces different results::
 
    >>> debug = lsstDebug.Info(__name__)  # __name__ selects the current task
    >>> debug.display
@@ -38,9 +40,14 @@ Then you can write your task to optionally enable a display (or whatever) by doi
    else:
       self.log.debug("I would show you a pretty picture here if you enabled debugging.")
 
+Task Users
+==========
+
 Refer to the `task documentation <http://doxygen.lsst.codes/stack/doxygen/x_masterDoxyDoc/group___l_s_s_t__task__documentation.html>`_ and look for “debug variables” to discover what debugging options are available for existing ``Task``\s.
 
-In order to load your specific debugging configuration, create a ``debug.py`` somewhere in your ``PYTHONPATH``, and put something like this in it::
+Your goal is to customize the behaviour of ``debug`` to meet your particular needs by redefining the ``lsstDebug.Info`` function to return an object that returns non-``False`` values for certain combinations of ``__name__`` and attribute.
+
+In order to load your specific debugging configuration, create a ``debug.py`` in a directory that is already in your ``PYTHONPATH`` or a new directory that you add to your ``PYTHONPATH``, and put something like this in it::
 
    import lsstDebug
    def DebugInfo(name):

--- a/coding/debug.rst
+++ b/coding/debug.rst
@@ -54,4 +54,4 @@ In order to load your specific debugging configuration, create a ``debug.py`` in
 That should enable debugging the ``display`` attribute when you are running inside ``lsst.meas.astrom.astrometry``, and disable it elsewhere.
 Of course, you can also return arbitrarily more complex objects, doing things like specifying the frame to display on etc.
 
-You may use the ``-d`` command line argument to pass a path to :file:`debug.py` to a command line task, rather than relying on it being found in your working directory.
+You must use the ``--debug`` command line argument to ask a command line task to import your :file:`debug.py` file.


### PR DESCRIPTION
The `-d` option doesn't exist, and `--debug` does not do what was described for `-d`.