### PR TITLE
Typo fix in multiline assignment rule (Python Style Guide)

### DIFF
--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -363,7 +363,7 @@ Error codes: E226 and E228.
 Keyword assignment operators SHOULD be surrounded by a space when statements appear on multiple lines
 -----------------------------------------------------------------------------------------------------
 
-However, if keyword assignments occur on a single line, where should be no additional spaces.
+However, if keyword assignments occur on a single line there should be no additional spaces.
 
 Thus this:
 


### PR DESCRIPTION
https://developer.lsst.io/v/u-jonathansick-python-style-guide-typo/coding/python_style_guide.html#keyword-assignment-operators-should-be-surrounded-by-a-space-when-statements-appear-on-multiple-lines