### PR TITLE
DM-11334: Pin documenteer < 0.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sphinx_rtd_theme==0.2.0
-Sphinx>=1.5.2
-documenteer>=0.1.11
+Sphinx>=1.5.2,<1.6.0
+documenteer>=0.1.11,<0.2.0


### PR DESCRIPTION
Documenteer 0.2.0 changes how dependencies for different projects are managed. We can do the work to sort out required dependencies and upgrade later.