### PR TITLE
DM-11291: Update Common Dataset Organization and Policy per RFC-362

### DIFF
--- a/services/datasets.rst
+++ b/services/datasets.rst
@@ -16,7 +16,7 @@ All data added to ``/datasets`` must adhere to the following format (caps are to
   (:lmod:`butler` root)
 - RERUN = REPO/rerun/PUBLIC | REPO/rerun/PRIVATE
   (processed results)
-- PUBLIC = <ticket>/PRIVATE
+- PUBLIC = <ticket>/PRIVATE | <tag>/PRIVATE (ex. 'HSC-RC'; RFC needed for new tags)
 - PRIVATE = private/<user> | ""
   (:ref:`see details below <CaveatForPrivate>`)
 - PREPROCESSED = preprocessed/<label>/ | preprocessed/<label>/<date>/


### PR DESCRIPTION
Allow RFC-approved tags for reruns in /datasets per RFC-362 (1)