### PR TITLE
DM-12661: Fix link to templates repo and other copy edits

### DIFF
--- a/build-ci/new_package.rst
+++ b/build-ci/new_package.rst
@@ -3,12 +3,12 @@ Adding a New Package to the Build
 #################################
 
 New packages intended for distribution to end users should generally be added
-as a dependency of a "top level product": these are the roots of the LSST
+as a dependency of a "top-level product:" these are the roots of the LSST
 package hierarchy. They include ``lsst_apps``, ``lsst_distrib``,
 ``qserv_distrib`` and ``lsst_sims``.
 
 Before adding a new dependency to any of these products, it must be approved
-through the usual :doc:`/processes/decision_process`: consensus must be
+through the :doc:`RFC process </processes/decision_process>`. Consensus must be
 reached regarding both the name and the suitability of the new package. Before
 adopting the RFC, implementation tickets should be created to cover package
 creation.
@@ -18,15 +18,15 @@ following the template in the `lsst/templates`_ repository. DM packaging of
 third party code should proceed as described in :doc:`third_party`.
 
 New packages must be added to the `LSST organization on GitHub`_ and access
-must be granted to appropriate teams. For DM written code, these include "Data
-Management" and "Overlords"; for third party code, "DM Externals" and
-"Overlords" (but *not* Data Management).
+must be granted to appropriate teams. For DM-written code, these include "Data
+Management" and "Overlords." For third-party code, use the "DM Externals" and
+"Overlords" (but *not* "Data Management") teams.
 
 The new package must be added to the `etc/repos.yaml file in the lsst/repos
 repository`_ along with its corresponding GitHub URL. This file is governed by
 a "self-merge" policy: upon opening a pull request, it will be checked by the
 :ref:`build-ci-travis` system, and developers may merge without further review
-on success. Refer to `RFC-75`_ for background.
+on success. Refer to :jira:`RFC-75` for background.
 
 The new package then needs to be added to the :file:`ups/*.table` file (and
 possibly the :file:`ups/*.cfg` file) of one or more other packages in the
@@ -34,35 +34,35 @@ stack where it is used.
 
 .. _lfs-repos:
 
-Handling Git LFS backed repos
-=================================
+Handling Git LFS-backed repos
+=============================
 
-New Git LFS (see :doc:`/tools/git_lfs`) backed repos (or existing repos
-being converted to `lfs`) require additional configuration.
+New :doc:`Git LFS-backed </tools/git_lfs>` repos (or existing repos
+being converted to LFS) require additional configuration.
 
-- The `repos.yaml`_ entry must declare that the repository is LFS backed.
+- The `repos.yaml`_ entry must declare that the repository is LFS backed:
 
   .. code-block:: yaml
 
-    afwdata:
-      url: https://github.com/lsst/afwdata.git
-      lfs: true
+      afwdata:
+        url: https://github.com/lsst/afwdata.git
+        lfs: true
 
   See the comment block at the top of `repos.yaml`_ for additional details.
 
-- At present, the EUPS `distrib` packaging mechanism does not support `lfs`
-  backed repos.  These products **must not** be added to any ``top`` level
+- At present, the EUPS distrib packaging mechanism does not support
+  LFS-backed repos. These products **must not** be added to any top-level
   meta-package or as a mandatory (non-``optional``) recursive dependency of a
-  ``top`` level package.
+  top-level package.
 
 - *Optional* dependencies must be added to `manifest.remap`_ to prevent the
-  creation of broken EUPS `distrib` packages.  Please note that the "self-merge"
-  policy of `RFC-75`_ does not apply to `manifest.remap`_.
+  creation of broken EUPS distrib packages. Please note that the "self-merge"
+  policy (:jira:`RFC-75`) does not apply to `manifest.remap`_.
 
-  *Unlike changes merged into* `repos.yaml`_, *modifications to*
-  `manifest.remap`_ *do not take immediate affect*
+  Unlike changes merged into `repos.yaml`_, modifications to
+  `manifest.remap`_ do not take immediate affect.
 
-  recommend procedure is to attach the modification PR to a DM Jira issue on the
+  We recommend that you attach the modification PR to a DM Jira issue on the
   ``Continuous Integration`` component.
 
 .. _LSST organization on GitHub: https://github.com/lsst
@@ -71,4 +71,3 @@ being converted to `lfs`) require additional configuration.
 .. _etc/repos.yaml file in the lsst/repos repository: https://github.com/lsst/repos/blob/master/etc/repos.yaml
 .. _repos.yaml: https://github.com/lsst/repos/blob/master/etc/repos.yaml
 .. _manifest.remap:  https://github.com/lsst/lsstsw/blob/master/etc/manifest.remap
-.. _RFC-75: https://jira.lsstcorp.org/browse/RFC-75

--- a/build-ci/new_package.rst
+++ b/build-ci/new_package.rst
@@ -66,7 +66,7 @@ being converted to `lfs`) require additional configuration.
   ``Continuous Integration`` component.
 
 .. _LSST organization on GitHub: https://github.com/lsst
-.. _lsst/templates: https://github.com/lsst/templates
+.. _lsst/templates: https://github.com/lsst/templates/tree/master/project_templates/stack_package
 .. _Distributing third-party packages with EUPS: https://confluence.lsstcorp.org/display/LDMDG/Distributing+third-party+packages+with+EUPS
 .. _etc/repos.yaml file in the lsst/repos repository: https://github.com/lsst/repos/blob/master/etc/repos.yaml
 .. _repos.yaml: https://github.com/lsst/repos/blob/master/etc/repos.yaml

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -652,7 +652,7 @@ This is also consistent with :pep:`8`, which `states <https://www.python.org/dev
 
    Comparisons to singletons like ``None`` should always be done with ``is`` or ``is not``, never the equality operators.
 
-For sequences, (:py:obj:`str`, :py:obj:`list`, :py:obj:`tuple`), use the fact that empty sequences are ``False``.
+For sequences, (``str``, ``list``, ``tuple``), use the fact that empty sequences are ``False``.
 
 Yes:
 
@@ -789,7 +789,7 @@ This is preferred over :meth:`~dict.keys`. Use :meth:`~dict.keys` when storing t
 
     k = list(mydict.keys())
 
-where :class:`list` ensures that a view or iterator is not being retained.
+where ``list`` ensures that a view or iterator is not being retained.
 
 .. _style-guide-py-subprocess:
 

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -589,7 +589,7 @@ Standard code order SHOULD be followed
 Within a module, follow the order:
 
 1. Shebang line, ``#! /usr/bin/env python`` (only for executable scripts)
-2. Module-level comments (such as the `license statement <https://github.com/lsst/templates/blob/master/CopyrightHeader.py>`__)
+2. Module-level comments (such as the `license statement <https://github.com/lsst/templates/tree/master/file_templates/stack_license_py>`__)
 3. Module-level docstring
 4. ``from __future__ import absolute_import, division, print_function``
 5. ``__all__ = [...]`` statement, if present

--- a/tools/sublime.rst
+++ b/tools/sublime.rst
@@ -90,19 +90,19 @@ To easily open files in SublimeText from the command-line, there is a ``subl`` `
 
 Some packages (installable via Package Control) that may help your development include,
 
-* ``Git Gutter`` to put marks next to the line numbers that identify added/modified/removed lines since the last git commit.
-* ``OmniMarkupPreviewer`` to allow live-view of formatted RestructuredText, MarkDown, etc. in a web browser.
+* ``Git Gutter`` to put marks next to the line numbers that identify added/modified/removed lines since the last Git commit.
+* ``OmniMarkupPreviewer`` to allow live-view of formatted reStructuredText, Markdown, and so on, in a web browser.
 
 .. _sublime-cpp:
 
 C++
 ===
 
-The  :ref:`clang-format <using_clang_format>` plugin can help you automatically keep your C++ in line with the DM coding style.
-Once you have clang-format configured on your sytem, install the Sublime package with the Package Manager: `Clang Format <https://packagecontrol.io/packages/Clang%20Format>`_.
+The  :ref:`clang-format <using_clang_format>` plugin can help you automatically keep your C++ in line with the :doc:`/coding/cpp_style_guide`.
+Once you have clang-format configured on your system, install the Sublime package with the Package Manager: `Clang Format <https://packagecontrol.io/packages/Clang%20Format>`_.
 
 There are two required settings to make Clang Format find the binary and configuration file: ``"binary"`` and ``"style": "File"``.
-On Ubuntu, ``binary`` should be ``clang-format-5.0``, while on macOS it should be ``/usr/local/bin/clang-format`` if you installed via homebrew.
+On Ubuntu, ``binary`` should be ``clang-format-5.0``, while on macOS it should be ``/usr/local/bin/clang-format`` if you installed via `Homebrew <https://brew.sh>`_.
 In addition, you configure your Clang Format (``clang-format.sublime-settings``) to automatically format on save.
 
 .. code-block:: json
@@ -114,15 +114,16 @@ In addition, you configure your Clang Format (``clang-format.sublime-settings``)
     }
 
 You can also set C++ syntax-specific settings to override the general settings above.
-Syntax-specific settings are defined by opening a file in the desired language and selecting `Preferences->Settings - Syntax-Specific`.
+Syntax-specific settings are defined by opening a file in the desired language and selecting ``Preferences -> Settings - Syntax-Specific``.
 For example, to have only one ruler at the C++ boundary:
 
 .. code-block:: json
 
-    // These settings override both User and Default settings for the C++ syntax
     {
         "rulers": [110]
     }
+
+These settings override both user and default settings for the C++ syntax.
 
 .. _sublime-python:
 
@@ -136,7 +137,7 @@ The built-in python syntax highlighting works well, but here are some potentiall
 SublimeLinter-flake8
 --------------------
 
-LSST uses ``flake8`` to check that our python code conforms to our :ref:`style guide <style-guide-py-version>`.
+LSST :ref:`uses flake8 <style-guide-py-flake8>` to check that our python code conforms to our :doc:`/coding/python_style_guide`.
 You can get SublimeText to check your python code inline and mark lines that do not follow our style with the `SublimeLinter <http://www.sublimelinter.com/en/latest/>`_ package.
 Install ``SublimeLinter`` and ``SublimeLinter-flake8`` via Package Control.
 Use the following configuration to conform to LSST's python style, to mark failing lines, and to provide a summary of failures on save that will let you go directly to those lines.
@@ -208,10 +209,10 @@ Note that there are SublimeLinter plugins for other languages (e.g. Restructured
     }
 
 
- ``Python PEP8 Autoformat`` lets one bulk reformat a number of python files to match a style.
- Use these settings to match LSST's python style when auto formatting:
+``Python PEP8 Autoformat`` lets one bulk reformat a number of python files to match a style.
+Use these settings to match LSST's python style when auto formatting:
 
-.. code-block:: json
+.. code-block:: text
 
     {
         // list codes for fixes; used by --ignore and --select


### PR DESCRIPTION
- Fix links to the newly restructured https://github.com/lsst/templates repo.
- Fix syntax warnings in `coding/python_style_guide.rst` and `build-ci/new_package.rst` pages.
- Minor copy edits to pages encountered making the above fixes.