### PR TITLE
Added ToC entry mentioning Python 3.6

### DIFF
--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -25,6 +25,12 @@ All DM Python code MUST work with Python 3
 
 All the Python code written by LSST Data Management must be runnable using Python 3.
 Python 2 will cease to be supported before LSST is operational (:pep:`373`).
+
+.. _style-guide-py-version-py36:
+
+We are writing Python 3.6
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
 The current baseline version is Python 3.6.
 
 .. _style-guide-py-version-py3-usage:


### PR DESCRIPTION
This parallels the C++ style guide and makes the reference version much easier to spot for the casual reader.