### PR TITLE
DM-13525: Improve numpydoc examples

### DIFF
--- a/docs/py_docs.rst
+++ b/docs/py_docs.rst
@@ -8,16 +8,36 @@ Documenting Python APIs with Docstrings
 
 We use Python docstrings to create reference documentation for our Python APIs.
 Docstrings are read by developers, interactive Python users, and readers of our online documentation.
-This page describes how to write these docstrings in Numpydoc, DM's standard format:
+This page describes how to write these docstrings in Numpydoc, DM's standard format.
+
+**Format reference:**
 
 - :ref:`py-docstring-basics`.
 - :ref:`py-docstring-rst`.
 - :ref:`py-docstring-sections`.
+
+  1. :ref:`Short Summary <py-docstring-short-summary>`
+  2. :ref:`Deprecation Warning <py-docstring-deprecation>`
+  3. :ref:`Extended Summary <py-docstring-extended-summary>`
+  4. :ref:`Parameters <py-docstring-parameters>`
+  5. :ref:`Returns <py-docstring-returns>` or :ref:`Yields <py-docstring-yields>`
+  6. :ref:`Other Parameters <py-docstring-other-parameters>`
+  7. :ref:`Raises <py-docstring-raises>`
+  8. :ref:`See Also <py-docstring-see-also>`
+  9. :ref:`Notes <py-docstring-notes>`
+  10. :ref:`References <py-docstring-references>`
+  11. :ref:`Examples <py-docstring-examples>`
+
+**How to format different APIs:**
+
 - :ref:`py-docstring-module-structure`.
 - :ref:`py-docstring-class-structure`.
 - :ref:`py-docstring-method-function-structure`.
 - :ref:`py-docstring-attribute-constants-structure`.
 - :ref:`py-docstring-property-structure`.
+
+**Learn by example:**
+
 - :ref:`py-docstring-example-module`.
 
 Treat the guidelines on this page as an extension of the :doc:`../coding/python_style_guide`.

--- a/docs/py_docs.rst
+++ b/docs/py_docs.rst
@@ -1216,10 +1216,6 @@ The best way to document these public attributes is by declaring the attribute a
 
 Notice that the :ref:`parameters <py-docstring-parameters>` to the ``__init__`` method are documented separately from the class attributes (highlighted).
 
-.. note::
-
-   Private attributes (prefixed by underscores: ``self._myAttribute``) do not need to be documented with docstrings.
-
 .. _py-docstring-property-structure:
 
 Documenting Class Properties

--- a/docs/py_docs.rst
+++ b/docs/py_docs.rst
@@ -1070,12 +1070,18 @@ For example:
 Examples of Constant and Class Attribute Docstrings
 ---------------------------------------------------
 
+Minimal constant or attribute example
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 Include the attribute or constant's type in parentheses at the end of the summary line:
 
 .. code-block:: py
 
    NAME = 'LSST'
    """Name of the project (`str`)."""
+
+Multi-section docstrings
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 Multi-section docstrings keep the type information in the summary line.
 For example:
@@ -1097,28 +1103,43 @@ For example:
       Requirements Document, LPM-17, URL https://ls.st/LPM-17
    """
 
+Attributes set in \_\_init\_\_ methods
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 In many classes, public attributes are set in the ``__init__`` method.
 The best way to document these public attributes is by declaring the attribute at the class level and including a docstring with that declaration:
 
 .. code-block:: python
+   :emphasize-lines: 12-18
 
    class Metric(object):
        """Verification metric.
 
-       [...]
+       Parameters
+       ----------
+       name : `str`
+           Name of the metric.
+       unit : `astropy.units.Unit`
+           Units of the metric.
        """
 
        name = None
-       """Name of the metric (`str`)."""
+       """Name of the metric (`str`).
+       """
 
        unit = None
-       """Units of the metric (`astropy.units.Unit`)."""
+       """Units of the metric (`astropy.units.Unit`).
+       """
 
-       def __init__(name, unit):
+       def __init__(self, name, unit):
            self.name = name
            self.unit = unit
 
-Private attributes (prefixed by underscores: ``self._myAttribute``) do not need to be documented with docstrings.
+Notice that the :ref:`parameters <py-docstring-parameters>` to the ``__init__`` method are documented separately from the class attributes (highlighted).
+
+.. note::
+
+   Private attributes (prefixed by underscores: ``self._myAttribute``) do not need to be documented with docstrings.
 
 .. _py-docstring-property-structure:
 

--- a/docs/py_docs.rst
+++ b/docs/py_docs.rst
@@ -383,8 +383,6 @@ For example:
            X-axis coordinate for the second point (the origin, by default).
        y0 : `float`, optional
            Y-axis coordinate for the second point (the origin, by default).
-
-       [...]
        """
 
 Each parameter is declared with a line formatted as ``{name} : {type}`` that is justified to the docstring.
@@ -774,10 +772,14 @@ Comments explaining the examples should have blank lines both above and below th
 
 .. code-block:: rst
 
+   Examples
+   --------
+   A simple example:
+
    >>> np.add(1, 2)
    3
 
-   Comment explaining the second example
+   Comment explaining the second example:
 
    >>> np.add([1, 2], [3, 4])
    array([4, 6])
@@ -785,6 +787,10 @@ Comments explaining the examples should have blank lines both above and below th
 For tests with a result that is random or platform-dependent, mark the output as such:
 
 .. code-block:: rst
+
+   Examples
+   --------
+   An example marked as creating a random result:
 
    >>> np.random.rand(2)
    array([ 0.35773152,  0.38568979])  #random
@@ -845,7 +851,7 @@ For example:
    Extended discussion of my module.
    """
 
-   import lsst.afw.table as afw_table
+   import lsst.afw.table as afwTable
    # [...]
 
 .. _py-docstring-class-structure:
@@ -881,16 +887,21 @@ Class docstrings must be placed directly below the declaration, and indented acc
    class MyClass(object):
        """Summary of MyClass.
 
-       [...]
+       Parameters
+       ----------
+       a : `str`
+          Documentation for the ``a`` parameter.
        """
 
-       def __init__(self):
+       def __init__(self, a):
            pass
+
+The ``__init__`` method never has a docstring since the class docstring documents the constructor.
 
 Examples of Class Docstrings
 ----------------------------
 
-Here's an example of a class:
+Here's an example of a more comprehensive class docstring with :ref:`Short Summary <py-docstring-short-summary>`, :ref:`Parameters <py-docstring-parameters>`, :ref:`Raises <py-docstring-raises>`, :ref:`See Also <py-docstring-see-also>`, and :ref:`Examples <py-docstring-examples>` sections:
 
 .. code-block:: python
 
@@ -958,16 +969,16 @@ Class, method, and function docstrings must be placed directly below the declara
    class MyClass(object):
        """Summary of MyClass.
 
-       [...]
+       Extended discussion of MyClass.
        """
 
        def __init__(self):
            pass
 
-       def method(self):
+       def myMethod(self):
            """Summary of method.
 
-           Extended Discussion of my method.
+           Extended Discussion of myMethod.
            """
            pass
 
@@ -1054,6 +1065,7 @@ Docstrings for module-level variables and class attributes appear directly below
 For example:
 
 .. code-block:: python
+   :emphasize-lines: 1-3,10-12
 
    MAX_ITER = 10
    """Maximum number of iterations (`int`).
@@ -1061,7 +1073,7 @@ For example:
 
 
    class MyClass(object):
-       """[...]
+       """Example class for documenting attributes.
        """
 
        x = None
@@ -1111,7 +1123,7 @@ In many classes, public attributes are set in the ``__init__`` method.
 The best way to document these public attributes is by declaring the attribute at the class level and including a docstring with that declaration:
 
 .. code-block:: python
-   :emphasize-lines: 12-18
+   :emphasize-lines: 14-20
 
    class Metric(object):
        """Verification metric.
@@ -1122,6 +1134,8 @@ The best way to document these public attributes is by declaring the attribute a
            Name of the metric.
        unit : `astropy.units.Unit`
            Units of the metric.
+       package : `str`, optional
+           Name of the package where this metric is defined.
        """
 
        name = None
@@ -1132,9 +1146,10 @@ The best way to document these public attributes is by declaring the attribute a
        """Units of the metric (`astropy.units.Unit`).
        """
 
-       def __init__(self, name, unit):
+       def __init__(self, name, unit, package=None):
            self.name = name
            self.unit = unit
+           self._package = package
 
 Notice that the :ref:`parameters <py-docstring-parameters>` to the ``__init__`` method are documented separately from the class attributes (highlighted).
 
@@ -1155,8 +1170,6 @@ For example:
 .. code-block:: python
 
    class Measurement(object):
-
-       # ...
 
        @property
        def quantity(self):

--- a/docs/py_docs.rst
+++ b/docs/py_docs.rst
@@ -570,6 +570,9 @@ Returns
 
 'Returns' is an explanation of the returned values and their types, in the same format as :ref:`'Parameters' <py-docstring-parameters>`.
 
+Basic example
+^^^^^^^^^^^^^
+
 If a sequence of values is returned, each value may be separately listed, in order:
 
 .. code-block:: python
@@ -585,6 +588,9 @@ If a sequence of values is returned, each value may be separately listed, in ord
            Y-axis pixel coordinate.
        """
        return self._x, self._y
+
+Dictionary return types
+^^^^^^^^^^^^^^^^^^^^^^^
 
 If a return type is `dict`, ensure that the key-value pairs are documented in the description:
 
@@ -602,6 +608,30 @@ If a return type is `dict`, ensure that the key-value pairs are documented in th
           - ``y``: y-axis coordinate (`int`).
         """
         return {'x': self._x, 'y': self._y}
+
+
+Struct return types
+^^^^^^^^^^^^^^^^^^^
+
+``lsst.pipe.base.Struct``\ s, returned by Tasks for example, are documented the same way as dictionaries:
+
+.. code-block:: python
+
+   def getCoord(self):
+       """Get the point's pixel coordinate.
+
+       Returns
+       -------
+       result : `lsst.pipe.base.Struct`
+          Result struct with components:
+
+          - ``x``: x-axis coordinate (`int`).
+          - ``y``: y-axis coordinate (`int`).
+        """
+        return lsst.pipe.base.Struct(x=self._x, y=self._y)
+
+Naming return variables
+^^^^^^^^^^^^^^^^^^^^^^^
 
 Note that the names of the returned variables do not necessarily correspond to the names of variables.
 In the previous examples, the variables ``x``, ``y``, and ``pixelCoord`` never existed in the method scope.

--- a/docs/py_docs.rst
+++ b/docs/py_docs.rst
@@ -17,6 +17,7 @@ This page describes how to write these docstrings in Numpydoc, DM's standard for
 - :ref:`py-docstring-class-structure`.
 - :ref:`py-docstring-method-function-structure`.
 - :ref:`py-docstring-attribute-constants-structure`.
+- :ref:`py-docstring-property-structure`.
 
 Treat the guidelines on this page as an extension of the :doc:`../coding/python_style_guide`.
 

--- a/docs/py_docs.rst
+++ b/docs/py_docs.rst
@@ -888,14 +888,26 @@ For example:
 .. code-block:: python
 
    #
-   # LSST Data Management System
-   # See COPYRIGHT file at the top of the source tree.
+   # This file is part of dm_dev_guide.
    #
-   # [...]
+   # Developed for the LSST Data Management System.
+   # This product includes software developed by the LSST Project
+   # (http://www.lsst.org).
+   # See the COPYRIGHT file at the top-level directory of this distribution
+   # for details of code ownership.
    #
-   # You should have received a copy of the LSST License Statement and
-   # the GNU General Public License along with this program. If not,
-   # see <http://www.lsstcorp.org/LegalNotices/>.
+   # This program is free software: you can redistribute it and/or modify
+   # it under the terms of the GNU General Public License as published by
+   # the Free Software Foundation, either version 3 of the License, or
+   # (at your option) any later version.
+   #
+   # This program is distributed in the hope that it will be useful,
+   # but WITHOUT ANY WARRANTY; without even the implied warranty of
+   # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   # GNU General Public License for more details.
+   #
+   # You should have received a copy of the GNU General Public License
+   # along with this program.  If not, see <http://www.gnu.org/licenses/>.
    #
    """Summary of MyModule.
 

--- a/docs/py_docs.rst
+++ b/docs/py_docs.rst
@@ -18,6 +18,7 @@ This page describes how to write these docstrings in Numpydoc, DM's standard for
 - :ref:`py-docstring-method-function-structure`.
 - :ref:`py-docstring-attribute-constants-structure`.
 - :ref:`py-docstring-property-structure`.
+- :ref:`py-docstring-example-module`.
 
 Treat the guidelines on this page as an extension of the :doc:`../coding/python_style_guide`.
 
@@ -1194,10 +1195,19 @@ Note:
 - Only document the property's "getter" method, not the "setter" (if present).
 - If a property does not have a "setter" method, include the words ``read-only`` after the type information.
 
+.. _py-docstring-example-module:
+
+Complete Example Module
+=======================
+
+.. literalinclude:: snippets/numpydocExample.py
+   :language: python
+
 Acknowledgements
 ================
 
 These docstring guidelines are derived/adapted from the `NumPy <https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`_ and `Astropy <http://docs.astropy.org/en/stable/_sources/development/docrules.txt>`_ documentation.
+The example module is adapted from the `Napoleon documentation <http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html#example-numpy>`_.
 
 NumPy is Copyright © 2005-2013, NumPy Developers.
 

--- a/docs/snippets/numpydocExample.py
+++ b/docs/snippets/numpydocExample.py
@@ -1,10 +1,11 @@
 #
-# LSST Data Management System
+# This file is part of dm_dev_guide.
 #
-# Copyright 2018 Association of Universities for Research in Astronomy, Inc.
-#
-# This product includes software developed by the
-# LSST Project (http://www.lsst.org/).
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,9 +17,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the LSST License Statement and
-# the GNU General Public License along with this program.  If not,
-# see <https://www.lsstcorp.org/LegalNotices/>.
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 """Example Python module with Numpydoc-formatted docstrings.
 

--- a/docs/snippets/numpydocExample.py
+++ b/docs/snippets/numpydocExample.py
@@ -1,0 +1,330 @@
+#
+# LSST Data Management System
+#
+# Copyright 2018 Association of Universities for Research in Astronomy, Inc.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+"""Example Python module with Numpydoc-formatted docstrings.
+
+This module demonstrates documentation written according to LSST DM's
+guidelines for `Documenting Python APIs with Docstrings`_. Docstrings have
+well-specified sections. This paragraph is considered an `Extended
+Summary`_. Permitted sections are listed in `Numpydoc Sections in Docstrings`_.
+You can't add arbitrary sections since they won't be parsed.
+
+Notes
+-----
+Usually we don't write extensive module docstrings. Focus the module docstring
+on information that a Stack developer needs to know when working inside that
+module. Module *users* typically won't see module docstrings (instead they will
+read module documentation topics written in the package's ``doc/`` directory).
+
+.. _`Documenting Python APIs with Docstrings`:
+   https://developer.lsst.io/docs/py_docs.html
+.. _`Extended Summary`:
+   https://developer.lsst.io/docs/py_docs.html#py-docstring-extended-summary
+.. _`Numpydoc Sections in Docstrings`:
+   https://developer.lsst.io/docs/py_docs.html#py-docstring-sections
+"""
+
+__all__ = ('MODULE_LEVEL_VARIABLE', 'moduleLevelFunction', 'exampleGenerator',
+           'ExampleClass', 'ExampleError')
+
+MODULE_LEVEL_VARIABLE = 12345
+"""Module level variable documented inline (`int`).
+
+The module variable's type is specified in the short summary, as shown above.
+Module variables (constants) can have extended descriptions, like this
+paragraph. For a complete list of sections permitted in constant docstrings see
+`Documenting Constants and Class Attributes`_.
+
+.. _`Documenting Constants and Class Attributes`:
+   https://developer.lsst.io/docs/py_docs.html#py-docstring-attribute-constants-structure
+"""
+
+
+def moduleLevelFunction(param1, param2=None, *args, **kwargs):
+    """Test that two parameters are not equal.
+
+    This is an example of a function docstring. Function parameters are
+    documented in the ``Parameters`` section. See *Notes* for the format
+    specification. See `Documenting Methods and Functions`_ for more
+    information about function docstrings.
+
+    Parameters
+    ----------
+    param1 : `int`
+        The first parameter. Note how the type is marked up with backticks.
+        This marks ``int`` as an API object so that Sphinx will attempt to
+        link to its reference documentation. You can do this for custom types
+        as well. You'll see an example in the `Returns`_ documentation.
+    param2 : `str`, optional
+        Optional arguments (those with defaults) always include the word
+        ``optional`` after the type info. See the `Parameters`_ section
+        documentation for details.
+    *args
+        Variable length argument list.
+    **kwargs
+        Arbitrary keyword arguments. If you do accept ``**kwargs``, make sure
+        you link to documentation that describes what keywords are accepted,
+        or list the keyword arguments here:
+
+        - ``key1``: description (`int`).
+        - ``key2``: description (`str`).
+
+    Returns
+    -------
+    success : `bool`
+        `True` if successful, `False` otherwise.
+
+        The return type is not optional. The ``Returns`` section may span
+        multiple lines and paragraphs. Following lines should be indented to
+        match the first line of the description.
+
+        The ``Returns`` section supports any reStructuredText formatting,
+        including literal blocks::
+
+            {
+                'param1': param1,
+                'param2': param2
+            }
+
+        See the `Returns`_ section documentation for details.
+
+    Raises
+    ------
+    AttributeError
+        Raised if <insert situation>.
+    ValueError
+        Raised if <insert situation>. See the `Raises`_ section documentation
+        for details.
+
+    Notes
+    -----
+    If ``*args`` or ``**kwargs`` are accepted, they should be listed as
+    ``*args`` and ``**kwargs``.
+
+    The format for a parameter is::
+
+        name : type
+            Description.
+
+            The description may span multiple lines. Following lines
+            should be indented to match the first line of the description.
+
+            Multiple paragraphs are supported in parameter descriptions.
+
+    See also
+    --------
+    exampleGenerator
+    ExampleClass
+
+    Examples
+    --------
+    If possible, include an API usage example using the doctest format:
+
+    >>> moduleLevelFunction('Hello', param2='World')
+    True
+
+    See the `Examples`_ section reference for details.
+
+    .. _`Documenting Methods and Functions`:
+       py-docstring-method-function-structure
+    .. _`Parameters`:
+       https://developer.lsst.io/docs/py_docs.html#py-docstring-parameters
+    .. _`Returns`:
+       https://developer.lsst.io/docs/py_docs.html#py-docstring-returns
+    .. _`Raises`:
+       https://developer.lsst.io/docs/py_docs.html#py-docstring-raises
+    .. _`Examples`:
+       https://developer.lsst.io/docs/py_docs.html#py-docstring-examples
+    """
+    if param1 == param2:
+        raise ValueError('param1 may not be equal to param2')
+    return True
+
+
+def exampleGenerator(n):
+    """Generate an increasing sequence of numbers from 0 to a given limit.
+
+    Generators have a ``Yields`` section instead of a ``Returns`` section.
+
+    Parameters
+    ----------
+    n : `int`
+        The upper limit of the range to generate, from 0 to ``n`` - 1.
+
+    Yields
+    ------
+    number : `int`
+        The next number in the range of 0 to ``n`` - 1.
+
+    See also
+    --------
+    moduleLevelFunction
+
+    Examples
+    --------
+    Examples should be written in doctest format, and should illustrate how to
+    use the function:
+
+    >>> print([i for i in example_generator(4)])
+    [0, 1, 2, 3]
+    """
+    for i in range(n):
+        yield i
+
+
+class ExampleClass(object):
+    """Example class.
+
+    Parameters
+    ----------
+    param1 : `str`
+        Description of ``param1``.
+    param2 : `list` of `str`
+        Description of ``param2``.
+    param3 : `int`, optional
+        Description of ``param3``.
+    """
+
+    attr1 = None
+    """Description of ``attr1`` (`str`).
+    """
+
+    attr2 = None
+    """Description of ``attr2`` (`list` of `str`).
+    """
+
+    attr3 = None
+    """Description of ``attr3`` (`int`).
+    """
+
+    attr4 = None
+    """Description of ``attr4`` (`list` of `str`).
+    """
+
+    def __init__(self, param1, param2, param3=None):
+        self.attr1 = param1
+        self.attr2 = param2
+        self.attr3 = param3
+
+        self.attr4 = ['attr4']
+
+    @property
+    def readonlyProperty(self):
+        """Properties are documented in their getter method (`str`, read-only).
+        """
+        return 'readonlyProperty'
+
+    @property
+    def readwriteProperty(self):
+        """Properties with both a getter and setter are documented in their
+        getter method (`list` of `str`).
+
+        If the setter method contains notable behavior, it should be mentioned
+        here as well.
+        """
+        return self.attr4
+
+    @readwriteProperty.setter
+    def readwriteProperty(self, value):
+        self.attr4 = value
+
+    def exampleMethod(self, param1, param2):
+        """Test that a situation is true.
+
+        Class methods are similar to regular functions. Always use the
+        imperative mood when writing the one-sentence summary of a method or
+        function.
+
+        Parameters
+        ----------
+        param1 : obj
+            The first parameter.
+        param2 : obj
+            The second parameter.
+
+        Returns
+        -------
+        success : `bool`
+            `True` if successful, `False` otherwise.
+
+        Notes
+        -----
+        Do not include the ``self`` parameter in the ``Parameters`` section.
+        """
+        return True
+
+    def __special__(self):
+        """At the moment, special members with docstrings are not published in
+        the HTML documentation.
+
+        You must still document special members.
+
+        Notes
+        -----
+        Special members are any methods or attributes that start with and end
+        with a double underscore.
+        """
+        pass
+
+    def _private(self):
+        """By default private members are not included in the HTML docs either.
+
+        Notes
+        -----
+        Private members are any methods or attributes that start with an
+        underscore and are *not* special. By default they are not included in
+        the output.
+
+        However, you should still provide docstrings for private members to
+        document code for internal developers.
+        """
+        pass
+
+
+class ExampleError(Exception):
+    """Example exception.
+
+    Exceptions are documented in the same manner as other classes.
+
+    Parameters
+    ----------
+    msg : `str`
+        Human readable string describing the exception.
+    code : `int`, optional
+        Numeric error code.
+
+    Notes
+    -----
+    Do not include the ``self`` parameter in the ``Parameters`` section.
+    """
+
+    msg = None
+    """Human readable string describing the exception (`str`).
+    """
+
+    code = None
+    """Numeric error code (`int`).
+    """
+
+    def __init__(self, msg, code=None):
+        self.msg = msg
+        self.code = code


### PR DESCRIPTION
https://developer.lsst.io/v/DM-13525/docs/py_docs.html

- Clarify that class attributes and parameters are documented separately.
- Example of returning an `lsst.pipe.base.Struct`.
- Full example module (based on http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html#example-numpy)
- Easier to use table of contents