### PR TITLE
DM-5383: Update copyright instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _build
 .DS_Store
 __pycache__
 .cache
+docs/snippets/license_preamble.py
+docs/snippets/license_preamble.cpp

--- a/README.md
+++ b/README.md
@@ -62,6 +62,6 @@ Remember to preview your published branch (see Step #5 of § *Contributing*, abo
 
 ## License
 
-Copyright 2015-2016 AURA/LSST.
+Copyright 2015-2018 Association of Universities for Research in Astronomy.
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" property="dct:title">LSST DM Developer Guide</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="http://www.lsst.org" property="cc:attributionName" rel="cc:attributionURL">Association of Universities for Research in Astronomy, Inc.</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.<br />Based on a work at <a xmlns:dct="http://purl.org/dc/terms/" href="https://github.com/lsst_dm/dm_dev_guide" rel="dct:source">https://github.com/lsst_dm/dm_dev_guide</a>.

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -235,11 +235,8 @@ Each Python file MUST contain the standard license preamble
 A copyright and license block using :ref:`the standard text <pkg-doc-code-preamble>` MUST be included at the top of each file.
 This can be written as a Python comment.
 
-   .. code-block:: python
-
-      #
-      # <template text>
-      #
+.. literalinclude:: ../docs/snippets/license_preamble.txt
+   :language: text
 
 .. _style-guide-py-line-length:
 

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -227,6 +227,20 @@ Style changes must be encapsulated in a distinct commit (see :ref:`git-commit-or
 
    :doc:`../docs/py_docs` provides guidelines for the :ref:`layout of docstrings <py-docstring-basics>`.
 
+.. _style-guide-license:
+
+Each Python file MUST contain the standard license preamble
+-----------------------------------------------------------
+
+A copyright and license block using :ref:`the standard text <pkg-doc-code-preamble>` MUST be included at the top of each file.
+This can be written as a Python comment.
+
+   .. code-block:: python
+
+      #
+      # <template text>
+      #
+
 .. _style-guide-py-line-length:
 
 Line Length MUST be less than or equal to 110 columns

--- a/coding/python_style_guide.rst
+++ b/coding/python_style_guide.rst
@@ -235,8 +235,8 @@ Each Python file MUST contain the standard license preamble
 A copyright and license block using :ref:`the standard text <pkg-doc-code-preamble>` MUST be included at the top of each file.
 This can be written as a Python comment.
 
-.. literalinclude:: ../docs/snippets/license_preamble.txt
-   :language: text
+.. literalinclude:: ../docs/snippets/license_preamble.py
+   :language: python
 
 .. _style-guide-py-line-length:
 

--- a/conf.py
+++ b/conf.py
@@ -12,6 +12,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import print_function
 import sys
 import os
 
@@ -401,3 +402,68 @@ intersphinx_mapping = {
     'pytest': ('http://pytest.org/latest', None),
     'pipelines': ('https://pipelines.lsst.io', None)
 }
+
+
+# Dynamically convert the license preamble code to Python and C++
+# If the output files already exist we compare what we would put in
+# them with what is there and only update the output files if they
+# differ. This prevents sphinx from continually trying to rebuild the
+# docs when nothing has really changed. This approach also stops us from
+# having to store context between builds.
+def read_file_contents(filename):
+    """Returns file contents. Returns None if file does not exist."""
+    contents = None
+    try:
+        with open(filename, "r") as fd:
+            contents = [line.rstrip() for line in fd]
+    except FileNotFoundError:
+        pass
+    return contents
+
+
+def form_output(input, fmt, pre=None, post=None):
+    output = []
+    if pre is not None:
+        output.append(pre)
+    for c in input:
+        output.append(fmt.format(c).rstrip())
+    if post is not None:
+        output.append(post)
+    return output
+
+
+def lists_equal(list1, list2):
+    if len(list1) != len(list2):
+        return False
+    for a, b in zip(list1, list2):
+        if a != b:
+            return False
+    return True
+
+
+def write_if_different(filename, content):
+    external = read_file_contents(filename)
+    if external is not None:
+        # compare content
+        equal = lists_equal(content, external)
+        if equal:
+            return
+
+    print("Writing new content in {}".format(filename))
+    with open(filename, "w") as fd:
+        for line in content:
+            print(line, file=fd)
+
+
+preamble_root = "docs/snippets/license_preamble"
+files = {ext: "{}.{}".format(preamble_root, ext) for ext in ("txt", "py", "cpp")}
+try:
+    preamble = read_file_contents(files["txt"])
+    python_out = form_output(preamble, "# {}")
+    write_if_different(files["py"], python_out)
+
+    cpp_out = form_output(preamble, " * {}", pre="/*", post=" */")
+    write_if_different(files["cpp"], cpp_out)
+except Exception:
+    # should this break the build?
+    pass

--- a/docs/cpp_docs.rst
+++ b/docs/cpp_docs.rst
@@ -40,8 +40,8 @@ The beginning of both header and source code files should include
 
 2. A copyright and license block (note: **NOT** a Doxygen comment block) using :ref:`the standard text <pkg-doc-code-preamble>`.
 
-.. literalinclude:: snippets/license_preamble.txt
-   :language: text
+.. literalinclude:: snippets/license_preamble.cpp
+   :language: cpp
 
 .. _cpp-doxygen-basics:
 

--- a/docs/cpp_docs.rst
+++ b/docs/cpp_docs.rst
@@ -40,11 +40,8 @@ The beginning of both header and source code files should include
 
 2. A copyright and license block (note: **NOT** a Doxygen comment block) using :ref:`the standard text <pkg-doc-code-preamble>`.
 
-   .. code-block:: cpp
-
-      /*
-       * <template text>
-       */
+.. literalinclude:: snippets/license_preamble.txt
+   :language: text
 
 .. _cpp-doxygen-basics:
 

--- a/docs/cpp_docs.rst
+++ b/docs/cpp_docs.rst
@@ -38,30 +38,12 @@ The beginning of both header and source code files should include
 
       // -*- lsst-c++ -*-
 
-2. A copyright and license block (note: **NOT** a Doxygen comment block)
+2. A copyright and license block (note: **NOT** a Doxygen comment block) using :ref:`the standard text <pkg-doc-code-preamble>`.
 
    .. code-block:: cpp
 
       /*
-       * LSST Data Management System
-       * Copyright 2008-2017 AURA/LSST.
-       *
-       * This product includes software developed by the
-       * LSST Project (http://www.lsst.org/).
-       *
-       * This program is free software: you can redistribute it and/or modify
-       * it under the terms of the GNU General Public License as published by
-       * the Free Software Foundation, either version 3 of the License, or
-       * (at your option) any later version.
-       *
-       * This program is distributed in the hope that it will be useful,
-       * but WITHOUT ANY WARRANTY; without even the implied warranty of
-       * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-       * GNU General Public License for more details.
-       *
-       * You should have received a copy of the LSST License Statement and
-       * the GNU General Public License along with this program. If not,
-       * see <http://www.lsstcorp.org/LegalNotices/>.
+       * <template text>
        */
 
 .. _cpp-doxygen-basics:

--- a/docs/package_docs.rst
+++ b/docs/package_docs.rst
@@ -63,7 +63,7 @@ At the same time, READMEs aren't a primary source of Stack documentation.
 Thus we recommend you use your README to describe the purpose of the repository in slightly more detail than the GitHub summary line, and to point developers to the Stack documentation.
 At your discretion, READMEs can also be used for developer-centric notices that you feel shouldn't be included in the main documentation.
 
-To be consistent with the rest of the Stack's documentation, READMEs should be in reStructuredText format and named ``README.rst`` in the root of your repository.
+To be consistent with the rest of the Stack's documentation, READMEs should be in reStructuredText format and named :file:`README.rst` in the root of your repository.
 
 We suggest this template:
 
@@ -145,7 +145,7 @@ The institutions contributing to the Data Management software use the following 
 LICENSE
 -------
 
-A ``LICENSE`` file in the repository's root is the canonical description of LSST's code licensing.
+A :file:`LICENSE` file in the repository's root is the canonical description of LSST's code licensing.
 
 We use the GPLv3 license and a copy of it can be obtained from https://www.gnu.org/licenses/gpl.txt.
 
@@ -160,7 +160,7 @@ This should normally be included in a comment block at the top of the file and s
 .. literalinclude:: snippets/license_preamble.txt
    :language: text
 
-where the package name is stated explicitly at the top.
+where the package name is stated explicitly at the top to attach it to a particular :file:`COPYRIGHT` file.
 
 .. _pkg-doc-contributing:
 
@@ -168,7 +168,7 @@ CONTRIBUTING.rst
 ----------------
 
 `GitHub popularized the use of CONTRIBUTING files to help open source developers stay on the same page <https://github.com/blog/1184-contributing-guidelines>`_.
-Whenever a GitHub Issue or Pull Request is made, GitHub will display a link to the `CONTRIBUTING.rst` file.
+Whenever a GitHub Issue or Pull Request is made, GitHub will display a link to the :file:`CONTRIBUTING.rst` file.
 
 .. code-block:: rst
 
@@ -211,7 +211,7 @@ Whenever a GitHub Issue or Pull Request is made, GitHub will display a link to t
 
    .. _LSST DM Team Culture and Conduct Standards: https://confluence.lsstcorp.org/display/LDMDG/Team+Culture+and+Conduct+Standards
 
-.. note:: Some of the documentation URLs listed in this ``CONTRIBUTING.rst`` guide don't exist yet.
+.. note:: Some of the documentation URLs listed in this :file:`CONTRIBUTING.rst` guide don't exist yet.
 
 .. _pkg-doc-user-guide:
 
@@ -220,7 +220,7 @@ The Package's User Guide in docs/
 
 The heart of a Stack package's documentation are files in the ``docs/`` directory [#]_.
 This content is ingested by Sphinx, our documentation build tool, to publish user guides for each package.
-In the following section we describe how to write the main documentation file, ``docs/index.rst``.
+In the following section we describe how to write the main documentation file, :file:`docs/index.rst`.
 
 ..
    For complex packages, documentation can be split across many files in the docs/ directory.
@@ -245,7 +245,7 @@ For every package's user guide, we strongly recommend using the following sectio
 6. "Python Reference"
 7. "C++ Reference"
 
-To implement this pattern, every package's ``index.rst`` should follow this basic template:
+To implement this pattern, every package's :file:`index.rst` should follow this basic template:
 
 .. code-block:: rst
 
@@ -303,7 +303,7 @@ To implement this pattern, every package's ``index.rst`` should follow this basi
 
    API reference for C++ developers
 
-We recommend that the entirety of a package's documentation be contained in a single ``index.rst`` file.
+We recommend that the entirety of a package's documentation be contained in a single :file:`index.rst` file.
 This minimal pagination makes it easier for readers for use their browser's search to find specific phrases.
 
 In the following sections we expand on key concepts in writing a package's user guide.

--- a/docs/package_docs.rst
+++ b/docs/package_docs.rst
@@ -91,14 +91,12 @@ We suggest this template:
 COPYRIGHT
 ---------
 
-We assert copyright information in a centralized ``COPYRIGHT`` file, located in the repository's root rather than attempting to track copyright in each file separately within a package.
-Using a ``COPYRIGHT`` file allows us to maintain copyright information more effectively than in source code comments.
-(See `RFC-45 <https://jira.lsstcorp.org/browse/RFC-45>`_ for background on this policy).
+We assert copyright information in a centralized :file:`COPYRIGHT` file, located in the repository's root, instead of in individual source files.
+Using a :file:`COPYRIGHT` file allows us to maintain copyright information more effectively than in source code comments.
+(See :jira:`RFC-45` and `this article from the Software Freedom Law Center <https://softwarefreedom.org/resources/2012/ManagingCopyrightInformation.html>`_ for background on this policy).
 
-Some code written before construction officially started will have an LSST Corporation copyright and this should not be changed unless it has erroneously been used for code after construction began in August 2015.
 During LSST construction, copyright is asserted by your employer and not centrally by AURA.
-
-The ``COPYRIGHT`` file should include a line for each legal entity that contributed to the package.
+The :file:`COPYRIGHT` file should include a line for each legal entity that contributed to the package.
 A common example may look like:
 
 .. code-block:: text
@@ -123,10 +121,13 @@ E.g.:
    Copyright 2012-2015 University of Washington
    Copyright 2015-2018 Association of Universities for Research in Astronomy
 
-These ``COPYRIGHT`` files should be updated during development and may be robotically refreshed.
+These :file:`COPYRIGHT` files should be updated during development and may be robotically refreshed.
 Automatically updating the files requires people committing to the repository use their :ref:`institutional email address <git-setup-institutional-email>`.
 
-The downside of using a single ``COPYRIGHT`` file is that moving a file between packages requires that both the source and destination ``COPYRIGHT`` files may need to be amended, since the copyright information is not included in the file being moved.
+If you move source files between packages, remember to audit the :file:`COPYRIGHT` file and move copyright assignments between packages as necessary.
+
+.. note::
+  Some code written before construction officially started will have an LSST Corporation copyright and this should not be changed unless it has erroneously been used for code after construction began in August 2015.
 
 Standard Institutional Copyrights
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -139,6 +140,9 @@ The institutions contributing to the Data Management software use the following 
 * The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory
 * University of Illinois Champaign-Urbana
 * California Institute of Technology
+
+Contributions from institutions or individuals outside of DM are accepted and the relevant copyright statement should be included in the file if appropriate.
+We do not require copyright assignment to AURA on external code contributions, but be aware that small patches are not generally sufficient to require assertion of copyright by the contributor.
 
 .. _pkg-doc-license:
 

--- a/docs/package_docs.rst
+++ b/docs/package_docs.rst
@@ -157,28 +157,8 @@ CODE PREAMBLE
 Each source file needs to include a short license and copyright statement.
 This should normally be included in a comment block at the top of the file and should take the following form:
 
-.. code-block:: text
-
-    This file is part of %package_name%.
-
-    Developed for the LSST Data Management System.
-    This product includes software developed by the LSST Project
-    (http://www.lsst.org).
-    See the COPYRIGHT file at the top-level directory of this distribution
-    for details of code ownership.
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+.. literalinclude:: snippets/license_preamble.txt
+   :language: text
 
 where the package name is stated explicitly at the top.
 

--- a/docs/package_docs.rst
+++ b/docs/package_docs.rst
@@ -49,7 +49,7 @@ From the root GitHub page of a Stack repository (e.g., https://github.com/lsst/a
 The **summary** should be a concise one-sentence description the repository.
 These summaries are critical for browsing repositories at https://github.com/lsst and for GitHub search.
 
-The **hompage** should be set to the package's user guide page in the deployed software documentation (point to the 'latest' branch of the documentation).
+The **homepage** should be set to the package's user guide page in the deployed software documentation (point to the 'latest' branch of the documentation).
 
 .. _pkg-doc-readme:
 
@@ -86,6 +86,60 @@ We suggest this template:
 
    See LICENSE and COPYRIGHT files.
 
+.. _pkg-doc-copyright:
+
+COPYRIGHT
+---------
+
+We assert copyright information in a centralized ``COPYRIGHT`` file, located in the repository's root rather than attempting to track copyright in each file separately within a package.
+Using a ``COPYRIGHT`` file allows us to maintain copyright information more effectively than in source code comments.
+(See `RFC-45 <https://jira.lsstcorp.org/browse/RFC-45>`_ for background on this policy).
+
+Some code written before construction officially started will have an LSST Corporation copyright and this should not be changed unless it has erroneously been used for code after construction began in August 2015.
+During LSST construction, copyright is asserted by your employer and not centrally by AURA.
+
+The ``COPYRIGHT`` file should include a line for each legal entity that contributed to the package.
+A common example may look like:
+
+.. code-block:: text
+
+   Copyright 2012-2015 LSST Corporation
+   Copyright 2015-2017 Association of Universities for Research in Astronomy
+
+Where the year range is changed as appropriate.
+If the code in a package has not been touched since 2015 and you are working on it in 2018, do not say "2012-2018" but instead use "2012-2015, 2018".
+You can determine this by looking at the repository change history.
+
+.. note::
+   Previously it was common to see AURA/LSST in the copyright assignment line.
+   This is not a legal entity and the fully-expanded name of AURA should be used.
+
+Use a line per institution even if the years are the same:
+E.g.:
+
+.. code-block:: text
+
+   Copyright 2012-2015 LSST Corporation
+   Copyright 2012-2015 University of Washington
+   Copyright 2015-2018 Association of Universities for Research in Astronomy
+
+These ``COPYRIGHT`` files should be updated during development and may be robotically refreshed.
+Automatically updating the files requires people committing to the repository use their :ref:`institutional email address <git-setup-institutional-email>`.
+
+The downside of using a single ``COPYRIGHT`` file is that moving a file between packages requires that both the source and destination ``COPYRIGHT`` files may need to be amended, since the copyright information is not included in the file being moved.
+
+Standard Institutional Copyrights
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The institutions contributing to the Data Management software use the following copyright statements:
+
+* Association of Universities for Research in Astronomy
+* University of Washington
+* The Trustees of Princeton University
+* The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory
+* University of Illinois Champaign-Urbana
+* California Institute of Technology
+
 .. _pkg-doc-license:
 
 LICENSE
@@ -93,45 +147,40 @@ LICENSE
 
 A ``LICENSE`` file in the repository's root is the canonical description of LSST's code licensing.
 
-The canonical source of this file's content is https://www.lsstcorp.org/LegalNotices/LsstLicenseStatement.txt, though ensure that it is named ``LICENSE`` in the repository.
+We use the GPLv3 license and a copy of it can be obtained from https://www.gnu.org/licenses/gpl.txt.
 
-.. _pkg-doc-copyright:
+.. _pkg-doc-code-preamble:
 
-COPYRIGHT
----------
+CODE PREAMBLE
+-------------
 
-We assert copyright information in a centralized ``COPYRIGHT`` file, located in the repository's root.
-Using a ``COPYRIGHT`` file allows us to maintain copyright information more effectively than in source code comments.
-(See `RFC-45 <https://jira.lsstcorp.org/browse/RFC-45>`_ for background on this policy).
-
-Default Copyright
-^^^^^^^^^^^^^^^^^
-
-By default, the ``COPYRIGHT`` file should look like:
+Each source file needs to include a short license and copyright statement.
+This should normally be included in a comment block at the top of the file and should take the following form:
 
 .. code-block:: text
 
-   Copyright AURA/LSST (2012-2015)
+    This file is part of %package_name%.
 
-Where the year range is changed as appropriate.
+    Developed for the LSST Data Management System.
+    This product includes software developed by the LSST Project
+    (http://www.lsst.org).
+    See the COPYRIGHT file at the top-level directory of this distribution
+    for details of code ownership.
 
-Complex Copyright Assignments
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-If multiple institutions contributed to the code over the same period, each institution can be listed. E.g.:
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-.. code-block:: text
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   Copyright University of Washington and AURA/LSST (2012-2015)
-
-If multiple institutions contributed to the code, but at different times, then each institution can be listed on a separate copyright line:
-
-.. code-block:: text
-
-   Copyright AURA/LSST (2012-2015)
-   Copyright University of Washington (2010-2014)
-
-As per `RFC-45 <https://jira.lsstcorp.org/browse/RFC-45>`_, these ``COPYRIGHT`` files will be robotically refreshed.
+where the package name is stated explicitly at the top.
 
 .. _pkg-doc-contributing:
 

--- a/docs/snippets/license_preamble.txt
+++ b/docs/snippets/license_preamble.txt
@@ -1,0 +1,20 @@
+This file is part of %package_name%.
+
+Developed for the LSST Data Management System.
+This product includes software developed by the LSST Project
+(http://www.lsst.org).
+See the COPYRIGHT file at the top-level directory of this distribution
+for details of code ownership.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.


### PR DESCRIPTION
Follows the discussion in RFC-45. I've also tried to factor out the license text that is present in each source in a single location referenced from C++ and Python guides.