### PR TITLE
DM-13582: Document Jenkins slack notifications

### DIFF
--- a/build-ci/jenkins-stack-os-matrix.rst
+++ b/build-ci/jenkins-stack-os-matrix.rst
@@ -47,6 +47,12 @@ The progress for each build step is listed on the run detail page.
 The most important build step is ``./buildbot-scripts/jenkins_wrapper.sh`` where the lsstsw rebuild is run.
 Click on that step to see build and test progress for each package.
 
+Getting stack-os-matrix notifications in Slack
+==============================================
+
+Jenkins sends status notifications to the `#dmj-stack-os-matrix`_ channel on Slack when your job starts and finishes.
+See :ref:`jenkins-slack-notifications` for more information.
+
 Viewing build and test results
 ==============================
 
@@ -60,3 +66,4 @@ You can even download all the logs and :file:`*.failed` files for a build by scr
 .. _`stack-os-matrix`: https://ci.lsst.codes/blue/organizations/jenkins/stack-os-matrix/activity
 .. _`lsst_ci`: https://github.com/lsst/lsst_ci
 .. _`lsst_dm_stack_demo`: https://github.com/lsst/lsst_dm_stack_demo
+.. _`#dmj-stack-os-matrix`: https://lsstc.slack.com/messages/C9A31S9MG

--- a/build-ci/jenkins.rst
+++ b/build-ci/jenkins.rst
@@ -100,6 +100,7 @@ Getting Job status in Slack
 ===========================
 
 When jobs start and end (either as a success or failure), Jenkins posts a message to the `#dm-jenkins`_ channel in the LSSTC Slack team.
+Jenkins also mentions developers in specific notification channels, see :ref:`jenkins-slack-notifications`.
 
 .. _jenkins-jobs:
 
@@ -140,6 +141,41 @@ qserv/qserv\_distrib
 `qserv/qserv_distrib`_ is automatically run nightly to test the ``master`` branches of all packages in the ``qserv_distrib`` stack.
 This job runs from a clean slate to discover issues that might be hidden by the caching behavior of the stack-os-matrix job.
 
+.. _jenkins-slack-notifications:
+
+Slack job notifications
+=======================
+
+You can get Slack notifications when a Jenkins job starts and stops.
+
+Configuring Slack to be "@"-mentioned
+-------------------------------------
+
+We recommend that you add your GitHub username to your Slack profile.
+This allows the Jenkins bot to send you an "@"-mention specifically for the Jenkins jobs that you trigger.
+The bot will also invite you to the notification channel if necessary.
+
+To do this, follow :doc:`../communications/slack-github-username`.
+
+Jenkins notification channels
+-----------------------------
+
+Each Jenkins job has its own notification channel.
+Each channel name starts with a ``#dmj-`` prefix.
+Due to length constrains, these channels have abbreviated names based on the Jenkins job.
+
+To find the channel corresponding to a job, `search the channel listing`_ for ``#dmj-`` channels.
+The full name of the Jenkins job is included in the channel's description.
+
+Controlling notifications from Jenkins channels
+-----------------------------------------------
+
+Jenkins notification Slack channels can be noisy.
+Typically you'll want to notice activity for only the jobs that you trigger.
+
+The best way to do this is to `mute the channel`_.
+The channel will still be highlighted when your jobs run because you will be ``@``-mentioned.
+
 More resources
 ==============
 
@@ -158,3 +194,5 @@ More resources
 .. _`Jenkins dashboard documentation`: https://jenkins.io/doc/book/blueocean/dashboard/
 .. _`lsst-sqre/jenkins-dm-jobs`: https://github.com/lsst-sqre/jenkins-dm-jobs
 .. _`#dm-jenkins`: https://lsstc.slack.com/messages/C2NCSTY3A
+.. _`search the channel listing`: https://get.slack.help/hc/en-us/articles/205239967-Browse-and-join-channels
+.. _`mute the channel`: https://get.slack.help/hc/en-us/articles/204411433-Mute-a-channel

--- a/communications/slack-github-username.rst
+++ b/communications/slack-github-username.rst
@@ -1,0 +1,13 @@
+######################################################
+Configuring your GitHub username in your Slack profile
+######################################################
+
+Some of DM's Slack integrations need to know your GitHub username to map your activity on GitHub to your Slack account.
+Here's how to help us do that by adding your GitHub username to your Slack profile:
+
+1. Visit Slack: https://lsstc.slack.com.
+
+2. Click on the **LSSTC** workspace label in the top-left corner and select **Profile & account** from the drop-down.
+
+3. Add your GitHub username to the **GitHub Username** field of your profile.
+   Don't include any prefix like ``@``.

--- a/index.rst
+++ b/index.rst
@@ -81,6 +81,7 @@ The `README <https://github.com/lsst-dm/dm_dev_guide/blob/master/README.md>`__ w
    :caption: Developer Tools
    :name: part-tools
 
+   communications/slack-github-username.rst
    tools/git_setup.rst
    tools/git_lfs.rst
    tools/jira_tips.rst


### PR DESCRIPTION
Documentation for the new Jenkins job notifications feature in Slack:

- [Slack job notifications](https://developer.lsst.io/v/DM-13582/build-ci/jenkins.html#slack-job-notifications)
- [Getting stack-os-matrix notifications in Slack](https://developer.lsst.io/v/DM-13582/build-ci/jenkins-stack-os-matrix.html#getting-stack-os-matrix-notifications-in-slack)
- [Configuring your GitHub username in your Slack profile](https://developer.lsst.io/v/DM-13582/communications/slack-github-username.html)