### PR TITLE
DM-13856: Add ITSC page

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -380,6 +380,22 @@ Crowd-sourced recommendations for configuring editors for LSST development (list
 Service guides
 ==============
 
+.. OVERVIEW SECTION ==========================================================
+
+.. toctree::
+   :maxdepth: 1
+   :caption: IT Overview
+   :hidden:
+
+   it/itsc
+
+.. _part-it:
+
+IT overview
+-----------
+
+- :doc:`it/itsc`
+
 .. JENKINS SECTION ===========================================================
 
 .. toctree::

--- a/it/index.rst
+++ b/it/index.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+###########
+IT Overview
+###########
+
+- :doc:`itsc`

--- a/it/itsc.rst
+++ b/it/itsc.rst
@@ -1,0 +1,69 @@
+.. _itsc:
+
+#####################################################
+LSST Information Technology Services Committee (ITSC)
+#####################################################
+
+Background
+==========
+
+On LSST, we have many entities (subsystems, SE, SQuaRE, PMO) selecting, purchasing, deploying, supporting, upgrading, and retiring IT Services for the MREFC project.
+We need robust vehicles for keeping everyone informed about all the services: who provides them, how to get support, are other groups planning something similar or have done something that can be leveraged, and what are the internal “service levels” defining what level of service and support can be expected.
+Many point-to-point communications and “local” channels have been set up to to address various aspects, but we now have a more integrated approach to achieve the goal of optimal management and support.
+
+Charter
+=======
+
+To address the above, the ITSC was chartered to:
+
+- Advise what ITS the project provides/uses.
+- Make sure interoperability exists among ITS where possible.
+- Combine, reuse, recycle ITS when possible.
+- Prevent ITS from becoming stagnant or security hazards.
+- Act as an agent of the project to keep project advised of what is going on at all spectrums of ITS.
+- Make recommendation whether a particular IT Service continues, when to retire/replace.
+- Make recommendations how the Project Office ITS (mail, web, issues, etc.) will transition into commissioning and operations.
+
+Scope
+=====
+
+The Project Office has final authority over any action or recommendation made by the IT Services Committee, especially if it results in a budgetary increase or has other consequences to project or observatory operations.
+Further, actions or recommendations cannot violate existing Information Technology Security Program and Compliance Policies:
+
+- :lpm:`121` – LSST Master Information Security Plan
+- :lpm:`123` – Acceptable Use Policy
+- Subsystem IT Security Plans: LPM , LDM, LTS, LCAM
+- :lpm:`141` – Compliance Policy
+
+The ITSC’s role of coordination and recommendation on ITS is currently chartered only in construction and commissioning.
+It is expected the ITSC or something like it will be chartered by the Observatory Director and will coordinate across Data Facility, Business, and Observatory Operations groups.
+
+Membership
+==========
+
+The ITSC consists of Core and Representative Members.
+The Core Members consist of representatives from entities that are key providers of IT Services to the project, including the PMO, the Tucson IT Services Team, the LSST Information Security Officer: Alex Withers, the DM NCSA team, the DM SQuARE team, and the LSST Compliance Officer: Veronica Kinnison (non-voting).
+
+The Representative Members represent a cross-section of the various project groups that have a responsibility for delivery consisting of and/or a vested interest in IT Services, including:  Systems Engineering, Data Management, Telescope and Site, Camera, and EPO.
+
+Process
+=======
+
+The ITSC meets monthly to review the status of IT Services and to process IT Requests for Consensus (ITRFCs).
+Meetings are open to anyone, agendas and minutes are public.
+ITRFCs are created by ITSC members to inform and to gather feedback from the overall project on the proposed introduction, update, or retirement events for IT Services.
+ITRFCs in JIRA are public (use `Project = ITRFC <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20%22IT%20Request%20For%20Comments%22%20>`_ to search issues).
+
+Your ITSC Representative Member is your primary interface to the ITSC responsible for:
+
+- Representing you in meetings and communications of the ITSC.
+- Making ITSC aware of your IT Services plans and proposals.
+- Making you aware of others IT Services plans and proposals.
+- Gathering your feedback on ITRFCs.
+
+Tools
+=====
+
+The ITSC has endorsed the creation and maintenance of an LSST-wide Services database.
+This database was prototyped as a Filemaker Database application and is currently accessible by ITSC.
+The database will be implemented on a more production platform, and will be public in future.


### PR DESCRIPTION
Describes the ITSC, using content provided by the ITSC.

This PR must be merged *after* #209.

Draft: https://developer.lsst.io/v/DM-13856/it/itsc.html