### PR TITLE
DM-14005: Update links to pybind11_example repository

### DIFF
--- a/pybind11/how-to.rst
+++ b/pybind11/how-to.rst
@@ -16,14 +16,14 @@ For far more detailed information please see the `pybind11 documentation <http:/
 Wrapping step-by-step
 =====================
 
-To illustrate how wrapping is done we will recreate the example wrappers from the `stack package template example`_.
+To illustrate how wrapping is done we will recreate the example wrappers from the `pybind11_example`_ repository.
 
 .. _wrapping-simple-class:
 
 Wrapping a simple class
 -----------------------
 
-We start by wrapping the basic ``ExampleOne`` class from the `stack package template example`_.
+We start by wrapping the basic `ExampleOne class in pybind11_example`_.
 Its header file looks like:
 
 .. code-block:: cpp
@@ -783,4 +783,5 @@ Create the appropriate ``__init__.py`` file, and put the following in
     ExampleThree.alias("F", ExampleThreeF)
     ExampleThree.alias("D", ExampleThreeD)
 
-.. _stack package template example: https://github.com/lsst/templates/tree/master/project_templates/stack_package/example
+.. _pybind11_example: https://github.com/lsst-dm/pybind11_example
+.. _`ExampleOne class in pybind11_example`: https://github.com/lsst-dm/pybind11_example/blob/master/src/ExampleOne.cc


### PR DESCRIPTION
Update the "Python wrappers for C++ with pybind11" tutorial (https://developer.lsst.io/v/DM-14005/pybind11/how-to.html) to point the relocated example package (we've moved it out of lsst/templates since the example is not formally a template).

See also:

- https://github.com/lsst-dm/pybind11_example/pull/1
- https://github.com/lsst/templates/pull/10