### PR TITLE
DM-13508: Add a note about a README.txt in `datasets`

### DIFF
--- a/services/datasets.rst
+++ b/services/datasets.rst
@@ -98,6 +98,15 @@ Responsibilities on ingest or maintenance
 - Ticket creator is responsible for butler-ization of dataset (or delegation of responsibility).
 - Responsibility for maintaining usable datasets is a DM-wide effort.
 
+Regardless of the reason for the RFC (implementaiton or maintenance), as part of implementing the RFC, any relevant information from the RFC should be transfered to a human readable file located in the root level of the dataset called ``README.txt``. There is no limit to how much information can be put in ``README.txt``, however at the minimum, it should contain:
+
+- A description of the instrument and observatory that produced the data
+- The percieved purpose of the dataset
+- At least a high level summary of the selection criteria for the dataset
+- The primary point of contact for questions about the dataset. Name is sufficient, but email would be appreciated.
+- If preprocessed, a description of the preprocessed data products available
+- If a subset is preprocessed, a description of how the subset was created (and why)
+
 
 .. _CaveatForPrivate:
 


### PR DESCRIPTION
I added a paragraph about including a `README.txt` in any new addition to datasets.  I'd like @jonathansick to have a look at it for content and syntax.