### PR TITLE
Maintenance updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -n
+SPHINXOPTS    = -n -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/conf.py
+++ b/conf.py
@@ -402,8 +402,8 @@ epub_exclude_files = ['search.html']
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'astropy': ('http://docs.astropy.org/en/stable/', None),
-    'numpy': ('http://docs.scipy.org/doc/numpy/', None),
-    'pytest': ('http://pytest.org/latest', None),
+    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'pytest': ('https://pytest.org/latest', None),
     'pipelines': ('https://pipelines.lsst.io', None)
 }
 

--- a/conf.py
+++ b/conf.py
@@ -66,7 +66,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'LSST DM Developer Guide'
-copyright = u'2016-2017 Association of Universities for Research in Astronomy, Inc.'
+copyright = u'2016-2018 Association of Universities for Research in Astronomy'
 author = u'LSST Data Management'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/services/monitoring_applications.rst
+++ b/services/monitoring_applications.rst
@@ -14,6 +14,7 @@ A draft of acceptable methods is outlined below.
 
 Method 1: Direct Injection to InfluxDB Endpoint
 ===============================================
+
 Streaming metrics straight into an InfluxDB database is an efficient way
 to inject data into the LDF monitoring framework.
 The `documentation for writing data into InfluxDB`_ is well define and very conventional.
@@ -26,6 +27,7 @@ relevant dashboards for those services.
 
 Method 2: Telegraf
 ==================
+
 Certain applications have built in support via the `Telegraf agent`_ which
 make deploying monitoring of a service fairly straight forward.
 One will have to include the telegraf package in the container image with
@@ -35,6 +37,7 @@ a proper output section format. See the :ref:`example <example01>` below.
 
 Method 3: Prometheus Endpoint 
 =============================
+
 Another option though sometimes less preferred due to a bit high memory
 footprint is to configure a Prometheus endpoint for the application that
 can be scraped by the LDF monitoring system.
@@ -47,10 +50,10 @@ If an integration is not provided there is documentation on writing a `custom in
 Example: Telegraf Output Configuration
 ======================================
 
-.. code-block: none
+.. code-block:: text
    :name: example01
 
-[[outputs.influxdb]]
-  database = "$database_name"
-  urls = ["https://$influxhostname:8086"]
+   [[outputs.influxdb]]
+     database = "$database_name"
+     urls = ["https://$influxhostname:8086"]
 


### PR DESCRIPTION
- Update copyright to 2018
- Fixup syntax errors
- Update intersphinx URLs to use https
- Turn warnings into breaking errors during the build to prevent syntax errors from making it to master in the future