### PR TITLE
Fix short summary description

### DIFF
--- a/python/numpydoc.rst
+++ b/python/numpydoc.rst
@@ -331,7 +331,7 @@ For summaries of how these docstring sections are composed in specific contexts,
 Short Summary
 -------------
 
-A one-line summary that does not use variable names or the function's name:
+A one-sentence summary that does not use variable names or the function's name:
 
 .. code-block:: python
 


### PR DESCRIPTION
This has always been meant to be "one-sentence" not "one-line" (literally).