### PR TITLE
DM-14852: Patch documenteer URLs

### DIFF
--- a/stack/building-pipelines-lsst-io-locally.rst
+++ b/stack/building-pipelines-lsst-io-locally.rst
@@ -181,9 +181,9 @@ Further reading
    - :doc:`building-single-package-docs`
    - Building pipelines.lsst.io with Jenkins CI
 
-.. _`Documenteer`: https://documenteer.lsst.io/v/DM-14852/
+.. _`Documenteer`: https://documenteer.lsst.io
 .. _`Documentation for the stack-docs command in Documenteer`:
-.. _`stack-docs command-line app`: https://documenteer.lsst.io/v/DM-14852/pipelines/stack-docs-cli.html
+.. _`stack-docs command-line app`: https://documenteer.lsst.io/pipelines/stack-docs-cli.html
 .. _`sqre/infrastructure/documenteer`: https://ci.lsst.codes/blue/organizations/jenkins/sqre%2Finfrastructure%2Fdocumenteer/activity
 .. _`pipelines.lsst.io`: https://pipelines.lsst.io
 .. _`pipelines_lsst_io`: https://github.com/lsst/pipelines_lsst_io

--- a/stack/building-single-package-docs.rst
+++ b/stack/building-single-package-docs.rst
@@ -144,13 +144,9 @@ Further reading
    - :doc:`building-pipelines-lsst-io-locally`
    - :doc:`building-pipelines-lsst-io-with-documenteer-job`
 
-.. todo::
-
-   FIXME update links after ``tickets/DM-14852`` is done.
-
-.. _`Documenteer`: https://documenteer.lsst.io/v/DM-14852/
+.. _`Documenteer`: https://documenteer.lsst.io
 .. _`Documenteer’s documentation for more information about the package-docs command`:
-.. _`Documentation for the package-docs command in Documenteer`: https://documenteer.lsst.io/v/DM-14852/pipelines/package-docs-cli.html
+.. _`Documentation for the package-docs command in Documenteer`: https://documenteer.lsst.io/pipelines/package-docs-cli.html
 .. _`pipelines.lsst.io`: https://pipelines.lsst.io
 .. _`pipelines_lsst_io`: https://github.com/lsst/pipelines_lsst_io
 .. _`pipe_base`: https://github.com/lsst/pipe_base

--- a/stack/documentation-system-overview.rst
+++ b/stack/documentation-system-overview.rst
@@ -91,7 +91,7 @@ See that technote to understand the design decisions behind the Stack documentat
 .. _`pipe_base`: https://github.com/lsst/pipe_base
 .. _`pipe_supertask`: https://github.com/lsst/pipe_supertask
 .. _`pex_config`: https://github.com/lsst/pex_config
-.. _`Documenteer`: https://documenteer.lsst.io/v/DM-14852/
+.. _`Documenteer`: https://documenteer.lsst.io
 .. _`sqre/infrastructure/documenteer`: https://ci.lsst.codes/blue/organizations/jenkins/sqre%2Finfrastructure%2Fdocumenteer/activity
 .. _`SQR-006`: https://sqr-006.lsst.io
 .. _`DMTN-030`:


### PR DESCRIPTION
Adjust link to documenteer.lsst.io now that DM-14852 has been merged.