### PR TITLE
Smaller example repo

### DIFF
--- a/git/git-lfs.rst
+++ b/git/git-lfs.rst
@@ -79,7 +79,7 @@ Trying cloning a small data repository to test your configuration:
 
 .. code-block:: bash
 
-   git clone https://github.com/lsst/testdata_decam
+   git clone https://github.com/lsst/testdata_subaru
 
 *That's it.*
 


### PR DESCRIPTION
So testdata_decam is 1.6 GB so takes a while. Testdata_subaru is 190 MB and that is also a git-lfs repo so maybe better for a test 