### PR TITLE
DM-15802: Remove references to DM-11216's branch

### DIFF
--- a/stack/building-pipelines-lsst-io-locally.rst
+++ b/stack/building-pipelines-lsst-io-locally.rst
@@ -34,17 +34,6 @@ Clone the repository:
 
    git clone https://github.com/lsst/pipelines_lsst_io
 
-.. important::
-
-   During this initial phase, ``tickets/DM-11216`` is the integration branch for multi-package builds of `pipelines_lsst_io`_.
-   For now you need to check out that branch:
-
-   .. code-block:: bash
-
-      cd pipelines_lsst_io
-      git checkout tickets/DM-11216
-      cd ..
-
 Then set up the `pipelines_lsst_io`_ package with EUPS:
 
 .. code:: bash

--- a/stack/building-single-package-docs.rst
+++ b/stack/building-single-package-docs.rst
@@ -44,12 +44,8 @@ In a base working directory — not inside a repository directory — create the
    python -m venv --system-site-packages --without-pip pyvenv
    source pyvenv/bin/activate
    curl https://bootstrap.pypa.io/get-pip.py | python
-   curl -O https://raw.githubusercontent.com/lsst/pipelines_lsst_io/tickets/DM-11216/requirements.txt
+   curl -O https://raw.githubusercontent.com/lsst/pipelines_lsst_io/master/requirements.txt
    pyvenv/bin/pip install -r requirements.txt
-
-.. todo::
-
-   FIXME update branch after ``tickets/DM-11216`` is done.
 
 .. note::
 


### PR DESCRIPTION
Now that that work is merged, developers can work against the `master` branch of https://github.com/lsst/pipelines_lsst_io