### PR TITLE
DM-15858: copyright.py breaks on Python 3.6+

### DIFF
--- a/legal/copyright.py
+++ b/legal/copyright.py
@@ -171,7 +171,7 @@ if __name__ == "__main__":
     if len(sys.argv) > 1:
         git_cmd += sys.argv[1:]
 
-    log = subprocess.check_output(git_cmd)
+    log = subprocess.check_output(git_cmd, universal_newlines=True)
 
     # Read in the full hashes of any commits deemed not copyrightable.
     insignificant_list = []


### PR DESCRIPTION
This PR fixes a bug where the `git log` output was being read as raw bytes rather than text, breaking parsing.