### PR TITLE
DM-16443: RST Guide Example Broken

### DIFF
--- a/restructuredtext/examples/figure.rst
+++ b/restructuredtext/examples/figure.rst
@@ -2,7 +2,7 @@
 
 .. figure:: /_static/development/docs/lsst_logo.jpg
    :name: fig-example-figure-label
-   :target: ../../_static/development/docs/lsst_logo.jpg
+   :target: ../_images/lsst_logo.jpg
    :alt: LSST Logo
 
    LSST Logo.

--- a/restructuredtext/examples/image.rst
+++ b/restructuredtext/examples/image.rst
@@ -1,5 +1,5 @@
 :orphan: True
 
 .. image:: /_static/development/docs/lsst_logo.jpg
-   :target: ../../_static/development/docs/lsst_logo.jpg
+   :target: ../_images/lsst_logo.jpg
    :alt: LSST Logo


### PR DESCRIPTION
This PR modifies the image linking example as discussed on the corresponding [Jira issue](https://jira.lsstcorp.org/browse/DM-16443). The new version of the page can be found at https://developer.lsst.io/v/DM-16443/restructuredtext/style.html.