### PR TITLE
DM-14360: Remove encoding field from bibliography directive

### DIFF
--- a/project-docs/technotes.rst
+++ b/project-docs/technotes.rst
@@ -109,7 +109,6 @@ First, add or uncomment the ``bibliography`` directive at the bottom of your tec
 .. code-block:: rst
 
    .. bibliography:: local.bib lsstbib/books.bib lsstbib/lsst.bib lsstbib/lsst-dm.bib lsstbib/refs.bib lsstbib/refs_ads.bib
-      :encoding: latex+latin
       :style: lsst_aa
 
 .. note::


### PR DESCRIPTION
In newer versions of sphinxcontrib-bibtex and its dependencies, the `latex+latin` encoding is no longer needed, and in fact has become an error:

```
unknown encoding: "latex+latin"
```