### PR TITLE
DM-16826: Clarify usage of "Extended summary" and "Notes" sections

### DIFF
--- a/cpp/api-docs.rst
+++ b/cpp/api-docs.rst
@@ -195,54 +195,16 @@ For functions and methods, the summary should be written in the imperative voice
 Extended Summary
 ----------------
 
-A few sentences giving an extended description.
-This section should be used to clarify *functionality*, not to discuss implementation detail or background theory, which should rather be explored in the :ref:`cpp-doxygen-notes` section below.
-You may refer to the parameters and the function name, but parameter descriptions still belong in the :ref:`cpp-doxygen-parameters` section unless they are very lengthy.
+The extended summary is an optional sentence or short paragraph that clarifies and supports the :ref:`summary sentence <cpp-doxygen-short-summary>`.
+Taken together with the summary sentence, the summary content in general exists to help users quickly understand the role and scope of the API.
 
-This section may include mathematical equations to describe the behavior of a class or method, but be sure to put math that pertains only to the implementation in the :ref:`cpp-doxygen-notes` section rather than the extended description.
-Equations may be written in `LaTeX <http://www.latex-project.org/>`_ format:
+Leave detailed discussions of the API's features, usage patterns, background theory, and implementation details to the :ref:`Notes <cpp-doxygen-notes>` and :ref:`Examples <cpp-doxygen-examples>` sections.
+The :ref:`Parameters <cpp-doxygen-parameters>` and :ref:`Returns <cpp-doxygen-returns>` sections are ideal places to discuss in detail individual parameters and returned values, respectively.
 
-.. code-block:: cpp
-
-   /**
-    * The FFT is a fast implementation of the discrete Fourier transform:
-    * @f[ X(e^{j\omega } ) = x(n)e^{ - j\omega n} @f]
-    */
-
-LaTeX environments can also be used:
-
-.. code-block:: cpp
-
-   /**
-    * The discrete-time Fourier time-convolution property states that
-    * @f{eqnarray*}
-    * x(n) * y(n) \Leftrightarrow X(e^{j\omega } )Y(e^{j\omega } )\\
-    * another equation here
-    * @f}
-    */
-
-Math can also be used inline:
-
-.. code-block:: cpp
-
-   /**
-    * Fit a model of the form @f$y = a x + b@f$ to the data.
-    */
-
-Note that LaTeX is not particularly easy to read, so use equations judiciously. In particular, do not use inline LaTeX just to add Greek or other special symbols; prefer `HTML character entities <http://www.doxygen.org/manual/htmlcmds.html>`_ or Unicode instead.
-
-Doxygen recovers poorly from typos in formulas; you may need to manually delete ``docs/html/formula.repository`` if it contains a bad formula.
-
-Images are allowed, but should not be central to the explanation; users viewing the documentation as text must be able to comprehend its meaning without resorting to an image viewer.
-These additional illustrations are included using:
-
-.. code-block:: cpp
-
-   /**
-    * @image html filename ["caption"]
-    */
-
-where ``filename`` is a path relative to the project root directory.
+This section's brevity is critical.
+The extended summary is proximate to the summary sentence so that the two pieces of content support each other.
+However, the extended summary also separates the API signature from the :ref:`Parameters <cpp-doxygen-parameters>` section, which users expect to see close together.
+As a general guideline, the extended summary should be three sentences or fewer.
 
 .. _cpp-doxygen-tparameters:
 
@@ -327,7 +289,7 @@ When two or more consecutive parameters have *exactly* the same description, the
 
 .. note::
 
-   Doxygen will not properly parse parameter descriptions that have multiple paragraphs. If your function's input requires a lengthy explanation, put the explanation in the :ref:`cpp-doxygen-extended-summary` and refer to it from the parameter descriptions.
+   Doxygen will not properly parse parameter descriptions that have multiple paragraphs. If your function's input requires a lengthy explanation, put the explanation in the :ref:`cpp-doxygen-notes` and refer to it from the parameter descriptions.
 
 .. _cpp-doxygen-parameters-inline:
 
@@ -484,9 +446,72 @@ For internal consistency, always use ``@see`` and not the synonymous ``@sa``.
 Notes
 -----
 
-*Notes* is an optional section that provides additional information about the code, possibly including a discussion of the algorithm or known limitations of the code. The notes must be prefixed by a ``@note`` or ``@warning`` command. Equations or images may be used as described in :ref:`cpp-doxygen-extended-summary`.
+*Notes* is an optional section that provides additional conceptual information about the API.
 
+The notes must be prefixed by a ``@note`` or ``@warning`` command.
 For internal consistency, always use ``@note`` and not the synonymous ``@remark`` or ``@remarks``.
+
+Some things to include in a *Notes* section:
+
+- Discussions of features, going beyond the level of the :ref:`summary sentence <py-docstring-short-summary>` and :ref:`extended summary <py-docstring-extended-summary>`.
+- Usage patterns, like how code is expected to use this API, or how this API is intended to be used in relation to other APIs.
+- Background theory. For example, if the API implements an algorithm, you can fully document the algorithm here.
+- Implementation details and limitations, if those details affect the user's experience.
+  Purely internal details should be written as regular code comments.
+
+Specific how-tos, tutorials, and examples go in the :ref:`Examples section <py-docstring-examples>` instead of *Notes*.
+The *Notes* section is dedicated to conceptual documentation.
+
+The :ref:`cpp-doxygen-parameters` and :ref:`cpp-doxygen-returns` sections are the best places to describe specific input and output variables.
+The *Notes* section can still reference these variables by name (see :ref:`py-docstring-parameter-markup`), and discuss how they work at a big-picture level.
+Since the content in the :ref:`cpp-doxygen-parameters` needs to be brief, you can write additional content as part of the *Notes* section.
+
+This section may include mathematical equations to document the algorithm implemented by the function or class.
+Equations may be written in `LaTeX <http://www.latex-project.org/>`_ format:
+
+.. code-block:: cpp
+
+   /**
+    * The FFT is a fast implementation of the discrete Fourier transform:
+    * @f[ X(e^{j\omega } ) = x(n)e^{ - j\omega n} @f]
+    */
+
+LaTeX environments can also be used:
+
+.. code-block:: cpp
+
+   /**
+    * The discrete-time Fourier time-convolution property states that
+    * @f{eqnarray*}
+    * x(n) * y(n) \Leftrightarrow X(e^{j\omega } )Y(e^{j\omega } )\\
+    * another equation here
+    * @f}
+    */
+
+Math can also be used inline:
+
+.. code-block:: cpp
+
+   /**
+    * Fit a model of the form @f$y = a x + b@f$ to the data.
+    */
+
+Note that LaTeX is not particularly easy to read, so use equations judiciously. In particular, do not use inline LaTeX just to add Greek or other special symbols; prefer `HTML character entities <http://www.doxygen.org/manual/htmlcmds.html>`_ or Unicode instead.
+
+Doxygen recovers poorly from typos in formulas; you may need to manually delete ``docs/html/formula.repository`` if it contains a bad formula.
+
+Images are allowed, but should not be central to the explanation; users viewing the documentation as text must be able to comprehend its meaning without resorting to an image viewer.
+These additional illustrations are included using the ``@image`` command:
+
+.. code-block:: cpp
+
+   /**
+    * @image html filename ["caption"]
+    */
+
+``filename`` is a path relative to the project root directory.
+
+Equations or images may be used as described in :ref:`cpp-doxygen-extended-summary`.
 
 .. _cpp-doxygen-references:
 

--- a/python/examples/numpydocExample.py
+++ b/python/examples/numpydocExample.py
@@ -23,24 +23,23 @@
 """Example Python module with Numpydoc-formatted docstrings.
 
 This module demonstrates documentation written according to LSST DM's
-guidelines for `Documenting Python APIs with Docstrings`_. Docstrings have
-well-specified sections. This paragraph is considered an `Extended
-Summary`_. Permitted sections are listed in `Numpydoc Sections in Docstrings`_.
-You can't add arbitrary sections since they won't be parsed.
+guidelines for `Documenting Python APIs with Docstrings`_.
 
 Notes
 -----
+Docstrings have well-specified sections. This is the Notes section. Permitted
+sections are listed in `Numpydoc Sections in Docstrings`_. You can't add
+arbitrary sections since they won't be parsed.
+
 Usually we don't write extensive module docstrings. Focus the module docstring
 on information that a Stack developer needs to know when working inside that
 module. Module *users* typically won't see module docstrings (instead they will
 read module documentation topics written in the package's ``doc/`` directory).
 
 .. _`Documenting Python APIs with Docstrings`:
-   https://developer.lsst.io/docs/py_docs.html
-.. _`Extended Summary`:
-   https://developer.lsst.io/docs/py_docs.html#py-docstring-extended-summary
+   https://developer.lsst.io/python/numpydoc.html
 .. _`Numpydoc Sections in Docstrings`:
-   https://developer.lsst.io/docs/py_docs.html#py-docstring-sections
+   https://developer.lsst.io/python/numpydoc.html#py-docstring-sections
 """
 
 __all__ = ('MODULE_LEVEL_VARIABLE', 'moduleLevelFunction', 'exampleGenerator',
@@ -64,8 +63,7 @@ def moduleLevelFunction(param1, param2=None, *args, **kwargs):
 
     This is an example of a function docstring. Function parameters are
     documented in the ``Parameters`` section. See *Notes* for the format
-    specification. See `Documenting Methods and Functions`_ for more
-    information about function docstrings.
+    specification.
 
     Parameters
     ----------
@@ -117,6 +115,13 @@ def moduleLevelFunction(param1, param2=None, *args, **kwargs):
 
     Notes
     -----
+    The Notes section is where you can write about the usage patterns and
+    background for the API. The bulk of the conceptual documentation goes
+    here, instead of it the extended summary. Save example code for the
+    "Examples" section.
+
+    **More about the Parameters section**
+
     If ``*args`` or ``**kwargs`` are accepted, they should be listed as
     ``*args`` and ``**kwargs``.
 
@@ -144,16 +149,14 @@ def moduleLevelFunction(param1, param2=None, *args, **kwargs):
 
     See the `Examples`_ section reference for details.
 
-    .. _`Documenting Methods and Functions`:
-       py-docstring-method-function-structure
     .. _`Parameters`:
-       https://developer.lsst.io/docs/py_docs.html#py-docstring-parameters
+       https://developer.lsst.io/python/numpydoc.html#py-docstring-parameters
     .. _`Returns`:
-       https://developer.lsst.io/docs/py_docs.html#py-docstring-returns
+       https://developer.lsst.io/python/numpydoc.html#py-docstring-returns
     .. _`Raises`:
-       https://developer.lsst.io/docs/py_docs.html#py-docstring-raises
+       https://developer.lsst.io/python/numpydoc.html#py-docstring-raises
     .. _`Examples`:
-       https://developer.lsst.io/docs/py_docs.html#py-docstring-examples
+       https://developer.lsst.io/python/numpydoc.html#py-docstring-examples
     """
     if param1 == param2:
         raise ValueError('param1 may not be equal to param2')
@@ -192,7 +195,8 @@ def exampleGenerator(n):
 
 
 class ExampleClass(object):
-    """Example class.
+    """An example class for demonstrating docstrings for classes, methods, and
+    attributes in the Numpydoc format.
 
     Parameters
     ----------
@@ -250,10 +254,6 @@ class ExampleClass(object):
     def exampleMethod(self, param1, param2):
         """Test that a situation is true.
 
-        Class methods are similar to regular functions. Always use the
-        imperative mood when writing the one-sentence summary of a method or
-        function.
-
         Parameters
         ----------
         param1 : obj
@@ -268,20 +268,26 @@ class ExampleClass(object):
 
         Notes
         -----
+        Class methods are similar to regular functions. Always use the
+        imperative mood when writing the one-sentence summary of a method or
+        function.
+
         Do not include the ``self`` parameter in the ``Parameters`` section.
         """
         return True
 
     def __special__(self):
-        """At the moment, special members with docstrings are not published in
-        the HTML documentation.
-
-        You must still document special members.
+        """Documentation for a special method.
 
         Notes
         -----
         Special members are any methods or attributes that start with and end
         with a double underscore.
+
+        At the moment, special members with docstrings are not published in
+        the HTML documentation.
+
+        You can still write docstrings for them, though.
         """
         pass
 
@@ -301,9 +307,7 @@ class ExampleClass(object):
 
 
 class ExampleError(Exception):
-    """Example exception.
-
-    Exceptions are documented in the same manner as other classes.
+    """An example exception.
 
     Parameters
     ----------
@@ -314,6 +318,8 @@ class ExampleError(Exception):
 
     Notes
     -----
+    Exceptions are documented in the same manner as other classes.
+
     Do not include the ``self`` parameter in the ``Parameters`` section.
     """
 

--- a/python/numpydoc.rst
+++ b/python/numpydoc.rst
@@ -454,9 +454,16 @@ Additional tips:
 Extended summary
 ----------------
 
-A few sentences giving an extended description.
-This section should be used to clarify *functionality*, not to discuss implementation detail or background theory, which should rather be explored in the :ref:`'Notes' <py-docstring-notes>` section below.
-You may refer to the parameters and the function name, but parameter descriptions still belong in the :ref:`'Parameters' <py-docstring-parameters>` section.
+The extended summary is an optional sentence or short paragraph that clarifies and supports the :ref:`summary sentence <py-docstring-short-summary>`.
+Taken together with the summary sentence, the summary content in general exists to help users quickly understand the role and scope of the API.
+
+Leave detailed discussions of the API's features, usage patterns, background theory, and implementation details to the :ref:`Notes <py-docstring-notes>` and :ref:`Examples <py-docstring-examples>` sections.
+The :ref:`Parameters <py-docstring-parameters>` and :ref:`Returns <py-docstring-returns>` sections are ideal places to discuss in detail individual parameters and returned values, respectively.
+
+This section's brevity is critical.
+The extended summary is proximate to the summary sentence so that the two pieces of content support each other.
+However, the extended summary also separates the API signature from the :ref:`Parameters <py-docstring-parameters>` section, which users expect to see close together.
+As a general guideline, the extended summary should be three sentences or fewer.
 
 .. _py-docstring-parameters:
 
@@ -849,8 +856,22 @@ Providing the full namespace is always safe, though, and provides clarity to fel
 Notes
 -----
 
-*Notes* is an optional section that provides additional information about the code, possibly including a discussion of the algorithm.
-Most reStructuredText formatting is allowed in the Notes section, including:
+*Notes* is an optional section that provides additional conceptual information about the API.
+Some things to include in a *Notes* section:
+
+- Discussions of features, going beyond the level of the :ref:`summary sentence <py-docstring-short-summary>` and :ref:`extended summary <py-docstring-extended-summary>`.
+- Usage patterns, like how code is expected to use this API, or how this API is intended to be used in relation to other APIs.
+- Background theory. For example, if the API implements an algorithm, you can fully document the algorithm here.
+- Implementation details and limitations, if those details affect the user's experience.
+  Purely internal details should be written as regular code comments.
+
+Specific how-tos, tutorials, and examples go in the :ref:`Examples section <py-docstring-examples>` instead of *Notes*.
+The *Notes* section is dedicated to conceptual documentation.
+
+The :ref:`Parameters <py-docstring-parameters>`, :ref:`Returns <py-docstring-returns>` and :ref:`Yields <py-docstring-yields>` sections are the best places to describe specific input and output variables in detail.
+The *Notes* section can still reference these variables by name (see :ref:`py-docstring-parameter-markup`), and discuss how they work at a big-picture level.
+
+Most reStructuredText formatting is allowed in the *Notes* section, including:
 
 - :ref:`Lists <rst-lists>`
 - :ref:`Tables <rst-tables>`

--- a/python/numpydoc.rst
+++ b/python/numpydoc.rst
@@ -304,7 +304,7 @@ We organize Python docstrings into sections that appear in a common order.
 This format is based on the original Numpydoc_ standard (used by NumPy, SciPy, and Astropy, among other scientific Python packages), though this style guide includes several DM-specific clarifications.
 These are the sections and their relative order:
 
-.. _Numpydoc: https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
+.. _Numpydoc: https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard
 
 1. :ref:`Short summary <py-docstring-short-summary>`
 2. :ref:`Extended summary <py-docstring-extended-summary>` (optional)
@@ -1373,7 +1373,7 @@ Complete example module
 Acknowledgements
 ================
 
-These docstring guidelines are derived/adapted from the `NumPy <https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`_ and `Astropy <http://docs.astropy.org/en/stable/_sources/development/docrules.txt>`_ documentation.
+These docstring guidelines are derived/adapted from the `NumPy <https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_ and `Astropy <http://docs.astropy.org/en/stable/_sources/development/docrules.txt>`_ documentation.
 The example module is adapted from the `Napoleon documentation <http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html#example-numpy>`_.
 
 NumPy is Copyright © 2005-2013, NumPy Developers.

--- a/python/numpydoc.rst
+++ b/python/numpydoc.rst
@@ -5,7 +5,7 @@
 .. _numpydoc-format:
 
 #######################################
-Documenting Python APIs with Docstrings
+Documenting Python APIs with docstrings
 #######################################
 
 We use Python docstrings to create reference documentation for our Python APIs.
@@ -18,13 +18,13 @@ This page describes how to write these docstrings in Numpydoc, DM's standard for
 - :ref:`py-docstring-rst`.
 - :ref:`py-docstring-sections`.
 
-  1. :ref:`Short Summary <py-docstring-short-summary>`
-  2. :ref:`Extended Summary <py-docstring-extended-summary>`
+  1. :ref:`Short summary <py-docstring-short-summary>`
+  2. :ref:`Extended summary <py-docstring-extended-summary>`
   3. :ref:`Parameters <py-docstring-parameters>`
   4. :ref:`Returns <py-docstring-returns>` or :ref:`Yields <py-docstring-yields>`
-  5. :ref:`Other Parameters <py-docstring-other-parameters>`
+  5. :ref:`Other parameters <py-docstring-other-parameters>`
   6. :ref:`Raises <py-docstring-raises>`
-  7. :ref:`See Also <py-docstring-see-also>`
+  7. :ref:`See also <py-docstring-see-also>`
   8. :ref:`Notes <py-docstring-notes>`
   9. :ref:`References <py-docstring-references>`
   10. :ref:`Examples <py-docstring-examples>`
@@ -45,7 +45,7 @@ Treat the guidelines on this page as an extension of the :doc:`style`.
 
 .. _py-docstring-basics:
 
-Basic Format of Docstrings
+Basic format of docstrings
 ==========================
 
 Python docstrings form the ``__doc__`` attributes attached to modules, classes, methods and functions.
@@ -65,7 +65,7 @@ For consistency, *do not* use triple single quotes: ``'''``.
 .. _py-docstring-form:
 
 Docstrings SHOULD begin with ``"""`` and terminate with ``"""`` on its own line
-----------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 
 The docstring's summary sentence occurs on the same line as the opening ``"""``.
 
@@ -178,7 +178,7 @@ Not:
 
 .. _py-docstring-rst:
 
-ReStructuredText in Docstrings
+ReStructuredText in docstrings
 ==============================
 
 We use reStructuredText to mark up and give semantic meaning to text in docstrings.
@@ -264,14 +264,14 @@ For example:
 
 .. _py-docstring-length:
 
-Line Lengths
+Line lengths
 ------------
 
 Hard-wrap text in docstrings to match the :ref:`docstring line length allowed by the coding standard <style-guide-py-docstring-line-length>`.
 
 .. _py-docstring-parameter-markup:
 
-Marking Up Parameter Names
+Marking up parameter names
 --------------------------
 
 The default reStructuredText role in docstrings is ``:py:obj:``.
@@ -293,7 +293,7 @@ For example, the description for ``format`` references the ``should_plot`` param
 
 .. _py-docstring-sections:
 
-Numpydoc Sections in Docstrings
+Numpydoc sections in docstrings
 ===============================
 
 We organize Python docstrings into sections that appear in a common order.
@@ -302,13 +302,13 @@ These are the sections and their relative order:
 
 .. _Numpydoc: https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
 
-1. :ref:`Short Summary <py-docstring-short-summary>`
-2. :ref:`Extended Summary <py-docstring-extended-summary>` (optional)
+1. :ref:`Short summary <py-docstring-short-summary>`
+2. :ref:`Extended summary <py-docstring-extended-summary>` (optional)
 3. :ref:`Parameters <py-docstring-parameters>` (if applicable; for classes, methods, and functions)
 4. :ref:`Returns <py-docstring-returns>` or :ref:`Yields <py-docstring-yields>` (if applicable; for functions, methods, and generators)
-5. :ref:`Other Parameters <py-docstring-other-parameters>` (if applicable; for classes, methods, and functions)
+5. :ref:`Other parameters <py-docstring-other-parameters>` (if applicable; for classes, methods, and functions)
 6. :ref:`Raises <py-docstring-raises>` (if applicable)
-7. :ref:`See Also <py-docstring-see-also>` (optional)
+7. :ref:`See also <py-docstring-see-also>` (optional)
 8. :ref:`Notes <py-docstring-notes>` (optional)
 9. :ref:`References <py-docstring-references>` (optional)
 10. :ref:`Examples <py-docstring-examples>` (optional)
@@ -323,7 +323,7 @@ For summaries of how these docstring sections are composed in specific contexts,
 
 .. _py-docstring-short-summary:
 
-Short Summary
+Short summary
 -------------
 
 A one-sentence summary that does not use variable names or the function's name:
@@ -345,7 +345,7 @@ Some examples:
 
 .. _py-docstring-extended-summary:
 
-Extended Summary
+Extended summary
 ----------------
 
 A few sentences giving an extended description.
@@ -406,7 +406,7 @@ For example:
 
 .. _py-docstring-parameter-types:
 
-Describing Parameter Types
+Describing parameter types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Be as precise as possible when describing parameter types.
@@ -506,7 +506,7 @@ For callback functions, describe the type as ``callable``:
 
 .. _py-docstring-optional:
 
-Optional Parameters
+Optional parameters
 ^^^^^^^^^^^^^^^^^^^
 
 For keyword arguments with useful defaults, add ``optional`` to the type specification:
@@ -658,7 +658,7 @@ For example:
 
 .. _py-docstring-other-parameters:
 
-Other Parameters
+Other parameters
 ----------------
 
 *For classes, methods and functions.*
@@ -708,7 +708,7 @@ Stylistically, write the first sentence of each description in the form:
 
 .. _py-docstring-see-also:
 
-See Also
+See also
 --------
 
 Use the 'See also' section to link to related APIs that the user may not be aware of, or may not easily discover from other parts of the docstring.
@@ -830,17 +830,17 @@ For more information on doctest, see:
 
 .. _py-docstring-module-structure:
 
-Documenting Modules
+Documenting modules
 ===================
 
-Sections in Module Docstrings
+Sections in module docstrings
 -----------------------------
 
 Module docstrings contain the following sections:
 
-1. :ref:`Short Summary <py-docstring-short-summary>`
-2. :ref:`Extended Summary <py-docstring-extended-summary>` (optional)
-3. :ref:`See Also <py-docstring-see-also>` (optional)
+1. :ref:`Short summary <py-docstring-short-summary>`
+2. :ref:`Extended summary <py-docstring-extended-summary>` (optional)
+3. :ref:`See also <py-docstring-see-also>` (optional)
 
 .. note::
 
@@ -850,7 +850,7 @@ Module docstrings contain the following sections:
 
    Module docstrings can still be useful for developer-oriented notes, though.
 
-Placement of Module Docstrings
+Placement of module docstrings
 ------------------------------
 
 Module-level docstrings must be placed as close to the top of the Python file as possible: *below* any ``#!/usr/bin/env python`` and license statements, but *above* imports.
@@ -893,27 +893,27 @@ For example:
 
 .. _py-docstring-class-structure:
 
-Documenting Classes
+Documenting classes
 ===================
 
 Class docstrings are placed directly after the class definition, and serve to document both the class as a whole *and* the arguments passed to the ``__init__`` constructor.
 
-Sections in Class Docstrings
+Sections in class docstrings
 ----------------------------
 
 Class docstrings contain the following sections:
 
-1. :ref:`Short Summary <py-docstring-short-summary>`
-2. :ref:`Extended Summary <py-docstring-extended-summary>` (optional)
+1. :ref:`Short summary <py-docstring-short-summary>`
+2. :ref:`Extended summary <py-docstring-extended-summary>` (optional)
 3. :ref:`Parameters <py-docstring-parameters>` (if applicable)
-4. :ref:`Other Parameters <py-docstring-other-parameters>` (if applicable)
+4. :ref:`Other parameters <py-docstring-other-parameters>` (if applicable)
 5. :ref:`Raises <py-docstring-raises>` (if applicable)
-6. :ref:`See Also <py-docstring-see-also>` (optional)
+6. :ref:`See also <py-docstring-see-also>` (optional)
 7. :ref:`Notes <py-docstring-notes>` (optional)
 8. :ref:`References <py-docstring-references>` (optional)
 9. :ref:`Examples <py-docstring-examples>` (optional)
 
-Placement of Class Docstrings
+Placement of class docstrings
 -----------------------------
 
 Class docstrings must be placed directly below the declaration, and indented according to the code scope:
@@ -934,7 +934,7 @@ Class docstrings must be placed directly below the declaration, and indented acc
 
 The ``__init__`` method never has a docstring since the class docstring documents the constructor.
 
-Examples of Class Docstrings
+Examples of class docstrings
 ----------------------------
 
 Here's an example of a more comprehensive class docstring with :ref:`Short Summary <py-docstring-short-summary>`, :ref:`Parameters <py-docstring-parameters>`, :ref:`Raises <py-docstring-raises>`, :ref:`See Also <py-docstring-see-also>`, and :ref:`Examples <py-docstring-examples>` sections:
@@ -975,26 +975,26 @@ Here's an example of a more comprehensive class docstring with :ref:`Short Summa
 
 .. _py-docstring-method-function-structure:
 
-Documenting Methods and Functions
+Documenting methods and functions
 =================================
 
-Sections in Method and Function Docstring Sections
+Sections in method and function docstring sections
 --------------------------------------------------
 
 Method and function docstrings contain the following sections:
 
-1. :ref:`Short Summary <py-docstring-short-summary>`
-2. :ref:`Extended Summary <py-docstring-extended-summary>` (optional)
+1. :ref:`Short summary <py-docstring-short-summary>`
+2. :ref:`Extended summary <py-docstring-extended-summary>` (optional)
 3. :ref:`Parameters <py-docstring-parameters>` (if applicable)
 4. :ref:`Returns <py-docstring-returns>` or :ref:`Yields <py-docstring-yields>` (if applicable)
-5. :ref:`Other Parameters <py-docstring-other-parameters>` (if applicable)
+5. :ref:`Other parameters <py-docstring-other-parameters>` (if applicable)
 6. :ref:`Raises <py-docstring-raises>` (if applicable)
-7. :ref:`See Also <py-docstring-see-also>` (optional)
+7. :ref:`See also <py-docstring-see-also>` (optional)
 8. :ref:`Notes <py-docstring-notes>` (optional)
 9. :ref:`References <py-docstring-references>` (optional)
 10. :ref:`Examples <py-docstring-examples>` (optional)
 
-Placement of Module and Function Docstrings
+Placement of module and function docstrings
 -------------------------------------------
 
 Class, method, and function docstrings must be placed directly below the declaration, and indented according to the code scope:
@@ -1028,14 +1028,14 @@ Class, method, and function docstrings must be placed directly below the declara
 Again, the :ref:`class docstring <py-docstring-class-structure>` takes the place of a docstring for the ``__init__`` method.
 ``__init__`` methods don't have docstrings.
 
-Dunder Methods
+Dunder methods
 --------------
 
 Special "dunder" methods on classes only need to have docstrings if they are doing anything non-standard.
 For example, if a ``__getslice__`` method cannot take negative indices, that should be noted.
 But if ``__ge__`` returns true if ``self`` is greater than or equal to the argument, that need not be documented.
 
-Examples of Method and Function Docstrings
+Examples of method and function docstrings
 ------------------------------------------
 
 Here's an example function:
@@ -1083,10 +1083,10 @@ Here's an example function:
 
 .. _py-docstring-attribute-constants-structure:
 
-Documenting Constants and Class Attributes
+Documenting constants and class attributes
 ==========================================
 
-Sections in Constant and Class Attribute Docstrings
+Sections in constant and class attribute docstrings
 ---------------------------------------------------
 
 Constants in modules and attributes in classes are all documented similarly.
@@ -1099,7 +1099,7 @@ They can also have a more complete structure with these sections:
 4. :ref:`References <py-docstring-references>` (optional)
 5. :ref:`Examples <py-docstring-examples>` (optional)
 
-Placement of Constant and Class Attribute Docstrings
+Placement of constant and class attribute docstrings
 ----------------------------------------------------
 
 Docstrings for module-level variables and class attributes appear directly below their first declaration.
@@ -1121,7 +1121,7 @@ For example:
        """Description of x attribute.
        """
 
-Examples of Constant and Class Attribute Docstrings
+Examples of constant and class attribute docstrings
 ---------------------------------------------------
 
 Minimal constant or attribute example
@@ -1196,7 +1196,7 @@ Notice that the :ref:`parameters <py-docstring-parameters>` to the ``__init__`` 
 
 .. _py-docstring-property-structure:
 
-Documenting Class Properties
+Documenting class properties
 ============================
 
 Properties are documented like :ref:`class attributes <py-docstring-attribute-constants-structure>` rather than methods.
@@ -1233,7 +1233,7 @@ Note:
 
 .. _py-docstring-example-module:
 
-Complete Example Module
+Complete example module
 =======================
 
 .. literalinclude:: examples/numpydocExample.py

--- a/python/numpydoc.rst
+++ b/python/numpydoc.rst
@@ -10,7 +10,11 @@ Documenting Python APIs with docstrings
 
 We use Python docstrings to create reference documentation for our Python APIs.
 Docstrings are read by developers, interactive Python users, and readers of our online documentation.
-This page describes how to write these docstrings in Numpydoc, DM's standard format.
+This page describes how to write these docstrings for LSST DM.
+
+Although this style guide grew out of Numpydoc_, and DM docstrings are parsed as Numpydoc, this style guide has small tweaks and clarifications compared to the original Numpydoc_ standard.
+Always refer to this guide, rather than others, to learn how to write DM docstrings.
+If you have any questions, ask in `#dm-docs <https://lsstc.slack.com/archives/dm-docs>`_ on Slack.
 
 **Format reference:**
 
@@ -297,7 +301,7 @@ Numpydoc sections in docstrings
 ===============================
 
 We organize Python docstrings into sections that appear in a common order.
-This format follows the `Numpydoc`_ standard (used by NumPy, SciPy, and Astropy, among other scientific Python packages) rather than the format described in :pep:`287`.
+This format is based on the original Numpydoc_ standard (used by NumPy, SciPy, and Astropy, among other scientific Python packages), though this style guide includes several DM-specific clarifications.
 These are the sections and their relative order:
 
 .. _Numpydoc: https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt

--- a/python/numpydoc.rst
+++ b/python/numpydoc.rst
@@ -67,7 +67,7 @@ For consistency, *do not* use triple single quotes: ``'''``.
 Docstrings SHOULD begin with ``"""`` and terminate with ``"""`` on its own line
 -------------------------------------------------------------------------------
 
-The docstring's summary sentence occurs on the same line as the opening ``"""``.
+The docstring's :ref:`summary sentence <py-docstring-short-summary>` occurs on the same line as the opening ``"""``.
 
 The terminating ``"""`` should be on its own line, even for 'one-line' docstrings (this is a minor departure from :pep:`257`).
 For example, a one-line docstring:
@@ -131,12 +131,12 @@ However, there should be a **single blank line before following code** such as c
 .. code-block:: py
 
    class Point(object):
-       """Point in a 2D cartesian space.
+       """A point in a 2D cartesian space.
 
        Parameters
        ----------
        x, y : `float`
-          Coordinate of the point.
+          The point's coordinate.
        """
 
        def __init__(x, y):
@@ -196,7 +196,7 @@ For example
 
 .. code-block:: python
 
-   """A summary
+   """A summary sentence.
 
    Notes
    -----
@@ -329,19 +329,125 @@ Short summary
 A one-sentence summary that does not use variable names or the function's name:
 
 .. code-block:: python
+   :emphasize-lines: 2
 
    def add(a, b):
        """Sum two numbers.
+
+       Parameters
+       ----------
+       a, b : `float`
+           The numbers to add together.
+
+       Returns
+       -------
+       sum : `float`
+           The sum of ``a`` and ``b``.
        """
        return a + b
 
+The summary sentence can wrap across multiple lines (see also :ref:`py-docstring-length`):
+
+.. code-block:: python
+   :emphasize-lines: 2-3
+
+   def sumif(sequence, conditional)
+       """Sum the numbers in a sequence as long as they pass a
+       user-provided conditional callback function.
+
+       Parameters
+       ----------
+       sequence : sequence of `float`
+           A sequence (`list`, for example) of numbers.
+       conditional : callable
+           A callback function that takes a single number as an
+           argument. The ``conditional`` function returns `True`
+           if the number passes the conditional, and `False`
+           otherwise.
+
+       Returns
+       -------
+       sum : `float`
+           The sum of numbers that meet the conditional.
+       """
+       total = 0
+       for n in sequence:
+           if conditional(n):
+               total += n
+        return total
+
+Do not write multiple sentences in the *Short summary*, however.
+If additional content is needed to clarify the *Short summary,* consider adding an :ref:`Extended summary <py-docstring-extended-summary>` section.
+
+Writing summaries for functions and methods
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 For functions and methods, write in the imperative voice.
-That is, the summary is treated a command that the API consumer can give.
+That is, the summary is treated as a command that the API consumer can give.
+
 Some examples:
 
-- ``Get metadata for all tasks.``
-- ``Make an `lsst.pex.config.ConfigurableField` for this task.``
-- ``Create a `Measurement` instance from a parsed YAML or JSON document.``
+- .. code-block:: python
+     :emphasize-lines: 2
+
+     def getMetadata(self):
+         """Get metadata for all tasks.
+
+         Returns
+         -------
+         metadata : `lsst.pipe.base.Struct`
+             The metadata.
+         """
+
+- .. code-block:: python
+     :emphasize-lines: 2
+
+     def makeRegistry(doc, configBaseType=Config):
+         """Create a `Registry`.
+
+         Parameters
+         ----------
+         doc : `str`
+             Docstring for the created `Registry` (this is set as the ``__doc__``
+             attribute of the `Registry` instance.
+         configBaseType : `lsst.pex.config.Config`-type
+             Base type of config classes in the `Registry`
+             (`lsst.pex.config.Registry.configBaseType`).
+
+         Returns
+         -------
+         registry : `Registry`
+             Registry with ``__doc__`` and `~Registry.configBaseType` attributes
+             set.
+         """
+
+Writing summaries for classes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+State what the class *is* through its summary sentence.
+
+Examples:
+
+- .. code-block:: python
+     :emphasize-lines: 2-4
+
+     class Job:
+         """A container for measurements, blobs, and metadata associated
+         with a pipeline run.
+         """
+
+- .. code-block:: python
+     :emphasize-lines: 2-4
+
+     class Field:
+         """A field in a `~lsst.pex.config.Config` class that supports `int`,
+         `float`, `complex`, `bool`, and `str` data types.
+         """
+
+Additional tips:
+
+- Don't repeat the class name in the summary sentence.
+- Don't write "This class..."
 
 .. _py-docstring-extended-summary:
 


### PR DESCRIPTION
This update replaces much of the inherited wording from the numpydoc spec to help us be more explicit about how the extended summary and notes sections of docstrings should be used. The extended summary exists to support the summary sentence. The Notes section is the heart of the docstring's conceptual documentation.

The C++ guidelines are also updated for parity.

Pending [RFC-558](
https://jira.lsstcorp.org/browse/RFC-558).

Drafts:

- [Documenting Python APIs with docstrings and Numpydoc](https://developer.lsst.io/v/DM-16826/python/numpydoc.html)
- [Documenting C++ code](
https://developer.lsst.io/v/DM-16826/cpp/api-docs.html)