### PR TITLE
DM-16814: Replace Packages section in C++ Documentation Guide

### DIFF
--- a/cpp/api-docs.rst
+++ b/cpp/api-docs.rst
@@ -45,6 +45,12 @@ The beginning of both header and source code files should include
 
    Replace ``{{ cookiecutter.package_name }}`` with the package's name.
 
+Some older code contains file-level Doxygen blocks (i.e., comments with a ``@file`` command).
+Such blocks should not be used in new code, as they rarely provide useful information about API elements defined by the file, and do not integrate well with `pipelines.lsst.io`_.
+Ordinary C++ comments may still be used to document files for developers reading the source code.
+
+.. _`pipelines.lsst.io`: https://pipelines.lsst.io
+
 .. _cpp-doxygen-basics:
 
 Basic Format of Documentation Blocks

--- a/cpp/api-docs.rst
+++ b/cpp/api-docs.rst
@@ -162,7 +162,6 @@ The sections and their relative order are:
 
 For summaries of how these sections are composed in specific contexts, see:
 
-- :ref:`cpp-doxygen-package-definition`
 - :ref:`cpp-doxygen-class-structure`
 - :ref:`cpp-doxygen-enum-structure`
 - :ref:`cpp-doxygen-method-function-structure`
@@ -540,38 +539,8 @@ Examples should use Markdown formatting for code blocks (i.e., indented by four 
 Documenting/Defining Packages
 =============================
 
-Each LSST package corresponds to a group in Doxygen.
-We declare this package in the root header file for a package, usually named ``package.h``.
-
-In this header file, below the boilerplate but above any ``#include`` statements or other code, provide a Doxygen comment block that declares the package with the fields:
-
-1. ``@defgroup`` followed by machine-readable and human-readable names for the package
-2. :ref:`cpp-doxygen-short-summary` (must be prefixed by ``@brief`` because the summary is not the first line.)
-3. :ref:`cpp-doxygen-deprecation` (if applicable)
-4. :ref:`cpp-doxygen-extended-summary` (recommended)
-5. :ref:`cpp-doxygen-see-also` (optional)
-
-For example:
-
-.. code-block:: cpp
-
-   /**
-    * @defgroup afw LSST Framework
-    *
-    * @brief LSST data management: astronomical framework, including images and tables
-    */
-
-Header files that belong to the package should have a Doxygen comment like
-
-.. code-block:: cpp
-
-   /**
-    * @addtogroup group
-    *
-    * @{
-    */
-
-before any documented code, and a Doxygen comment with a ``@}`` after any documented code. Everything between the ``@{`` and the ``@}`` will be listed on the module page.
+LSST packages are no longer documented using Doxygen.
+Instead, they should be documented using the Sphinx :ref:`module-homepage`.
 
 .. _cpp-doxygen-class-structure:
 


### PR DESCRIPTION
This PR requests that packages be documented using the new Sphinx system, and adds a comment explaining the existing policy behind `@file` (some questions about it came up during the December UW/Princeton numpydoc hack week).

Note that the C++ wording is slightly different from the [Python equivalent](https://developer.lsst.io/python/numpydoc.html#py-docstring-module-structure), but I'd argue that that's necessary because of differences in the two languages (in C++, "file" and "module" are essentially independent concepts).