### PR TITLE
DM-11462: Start the user documentation style guide

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -66,7 +66,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'LSST DM Developer Guide'
-copyright = u'2016-2018 Association of Universities for Research in Astronomy'
+copyright = u'2016-2019 Association of Universities for Research in Astronomy'
 author = u'LSST Data Management'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/index.rst
+++ b/index.rst
@@ -16,7 +16,7 @@ Check out the `README <https://github.com/lsst-dm/dm_dev_guide/blob/master/READM
 
 **Jump to:** :ref:`Team <part-team>` · :ref:`Communications <part-communications>` · :ref:`Project documentation <part-project-docs>` · :ref:`Work management <part-work>`
 
-**Development guides:** :ref:`Overview <part-guides>` · :ref:`C++ <part-cpp>` · :ref:`Python <part-python>` · :ref:`Pybind11 <part-pybind11>` · :ref:`JavaScript <part-javascript>` · :ref:`ReStructuredText <part-rst>` · :ref:`DM Stack <part-dm-stack>` · :ref:`Git <part-git>` · :ref:`Editors <part-editors>` · :ref:`Legal <part-legal>`
+**Development guides:** :ref:`Overview <part-guides>` · :ref:`C++ <part-cpp>` · :ref:`Python <part-python>` · :ref:`Pybind11 <part-pybind11>` · :ref:`JavaScript <part-javascript>` · :ref:`ReStructuredText <part-rst>` · :ref:`DM Stack <part-dm-stack>` · :ref:`Git <part-git>` · :ref:`Editors <part-editors>` · :ref:`Legal <part-legal>` · :ref:`User documentation style <part-user-doc-style-guide>`
 
 **Services:** :ref:`Overview <part-services>` · :ref:`Jenkins <part-jenkins>` · :ref:`LSST Data Facility <part-ldf>`
 
@@ -429,6 +429,24 @@ Legal
 
 - :doc:`legal/licensing-overview`
 - :doc:`legal/copyright-overview`
+
+.. USER DOC STYLE GUIDE SECTION =============================================
+
+.. Hidden toctree to manage the sidebar navigation. Match the contents list below.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: User docs
+   :hidden:
+
+   user-docs/index
+
+.. _part-user-doc-style-guide:
+
+User documentation style
+------------------------
+
+- :doc:`user-docs/index`
 
 .. _part-services:
 

--- a/index.rst
+++ b/index.rst
@@ -447,6 +447,7 @@ User documentation style
 ------------------------
 
 - :doc:`user-docs/index`
+- :doc:`user-docs/lsst-specific-content-style-guide`
 
 .. _part-services:
 

--- a/user-docs/index.rst
+++ b/user-docs/index.rst
@@ -1,0 +1,68 @@
+.. _user-doc-style-guide:
+
+##############################
+User documentation style guide
+##############################
+
+This style guide will help you write technical end-user documentation content for LSST Data Management.
+
+.. _user-doc-style-guide-list:
+
+The style guides
+================
+
+Our core style is described by the `Google Developer Style Guide`_, plus a list of customizations.
+
+-  View the `Google Developer Style Guide`_.
+-  View the LSST style customizations.
+
+If the Google Developer Style Guide doesn’t address your situation, you can fall back to these resources:
+
+- `Project Publications Style Guide <https://ls.st/Document-13016>`__
+- `The Chicago Manual of Style <http://www.chicagomanualofstyle.org/>`__
+- The `Merriam-Webster <https://www.merriam-webster.com>`__ dictionary
+
+.. _user-doc-style-guide-where:
+
+Where to use this style guide
+=============================
+
+This style guide is for LSST’s end-user documentation.
+A user is anyone that *uses* the software and services we build for LSST.
+Users can be astronomers in the community, future operators of LSST, and even your fellow developers.
+
+More specifically, refer to this style guide when writing any content that services a user:
+
+- Documentation content (guides, tutorials, how-tos, and references) for software and services.
+- Content for LSST websites.
+- “Docstrings” in code that are used as API references.
+- Copy printed to the console (like error messages).
+- User interface microcopy.
+
+There are common contexts where this style guide **does not** apply:
+
+- Project documentation (such as policy, requirements, design, test documents, and technical notes).
+- Academic manuscripts (such as papers and conference proceedings).
+
+In those contexts, use the `Project Publications Style Guide <https://ls.st/Document-13016>`__ or the journal’s style guide.
+
+.. _user-doc-style-guide-howto:
+
+How to use this style guide
+===========================
+
+In LSST DM, we are all responsible for contributing to the documentation for the things we create.
+At the same time, writing technical documentation for users differs in many ways from other types of writing we might have more experience in (such as academic writing).
+Given that, treat this style guide as an educational resource.
+As you learn more from this style guide, your technical writing will improve, and LSST’s documentation as a whole will become better and more consistent.
+
+It’s not realistic to expect you to internalize every facet of this style guide immediately.
+Instead, begin by reviewing the `Highlights <https://developers.google.com/style/highlights>`__.
+As you write content and have questions, refer to the style guide for solutions to your particular writing problems.
+Reviewers in a pull request might point out style issues.
+If it’s realistic in the time available, try to update your content to fit the recommended style.
+In any case, be open to learning so that the next batch of content you create will be even better.
+
+See the `About this guide <https://developers.google.com/style/highlights>`__ page from the Google Developer Style Guide for additional thoughts, including when to break the rules.
+
+.. _`Google Developer Style Guide`: https://developers.google.com/style/

--- a/user-docs/index.rst
+++ b/user-docs/index.rst
@@ -6,6 +6,11 @@ User documentation style guide
 
 This style guide will help you write technical end-user documentation content for LSST Data Management.
 
+.. toctree::
+   :hidden:
+
+   lsst-specific-content-style-guide
+
 .. _user-doc-style-guide-list:
 
 The style guides
@@ -13,8 +18,8 @@ The style guides
 
 Our core style is described by the `Google Developer Style Guide`_, plus a list of customizations.
 
--  View the `Google Developer Style Guide`_.
--  View the LSST style customizations.
+- View the `Google Developer Style Guide`_.
+- View the :doc:`LSST style customizations </user-docs/lsst-specific-content-style-guide>`.
 
 If the Google Developer Style Guide doesn’t address your situation, you can fall back to these resources:
 

--- a/user-docs/lsst-specific-content-style-guide.rst
+++ b/user-docs/lsst-specific-content-style-guide.rst
@@ -1,0 +1,33 @@
+.. _user-doc-style-lsst:
+
+#########################
+LSST-specific style guide
+#########################
+
+The :doc:`LSST user documentation style guide </user-docs/index>` is built upon the `Google Developer Style Guide`_.
+This page lists our exceptions and modifications to those guidelines.
+
+Use the imperative mood for Python and C++ function and method summary sentences
+--------------------------------------------------------------------------------
+
+For LSST DM Python and C++, you should use the **imperative mood** to write the summary sentence:
+
+   Get the value.
+
+The imperative mood is conventional in scientific Python software (Numpy, SciPy, and Astropy, among others).
+In turn, our C++ standard follows the Python convention since our use of the two languages is often intertwined.
+See also:
+
+- :ref:`Python summary sentence standard <py-docstring-short-summary>`
+- :ref:`C++ summary sentence standard <cpp-doxygen-short-summary>`
+
+.. note::
+
+   This recommendation for LSST DM differs from the Google Developer Style Guide, which recommends `using the present tense for function and method summaries <https://developers.google.com/style/api-reference-comments#methods>`__.
+   For example:
+
+       Gets the value.
+
+   If you are documenting a completely different technology, such as HTTP API endpoints, using the present tense is a good idea.
+
+.. _`Google Developer Style Guide`: https://developers.google.com/style/


### PR DESCRIPTION
This PR implements the idea of a user documentation content style guide that's based on Google's, with tweaks for LSST use cases. [RFC-555](https://jira.lsstcorp.org/browse/RFC-555)

There are a lot of additional areas this can go. I'd like to compile a bibliography of technical communication books, blogs, and talks, for instance. But this scope is enough for the style guide project to start being useful.

Preview of the entrypoint to the guide: https://developer.lsst.io/v/DM-11462/index.html#part-user-doc-style-guide