### PR TITLE
Fix URL for LPM-162.

### DIFF
--- a/project-docs/publication-policy.rst
+++ b/project-docs/publication-policy.rst
@@ -20,9 +20,9 @@ Links
 =====
 
 - `Publication Board homepage <https://project.lsst.org/documents/publication-board>`__.
-- `LPM-162: LSST Project Publication Policy <https://www.lsstcorp.org/docushare/dsweb/Get/LPM-162/>`__.
+- `LPM-162: LSST Project Publication Policy <https://ls.st/lpm-162>`__.
 - `Publication Board JIRA Project (PUB) <https://jira.lsstcorp.org/browse/PUB>`__.
-- `Document-13016: Project Publications Style Manual <https://docushare.lsstcorp.org/docushare/dsweb/Get/Document-13016/LSSTStyleManual.pdf>`__.
+- `Document-13016: Project Publications Style Manual <https://ls.st/Document-13016>`__.
 - `lsst-pst/LSSTreferences <https://github.com/lsst-pst/LSSTreferences>`__ GitHub project with citations for key LSST papers.
 
 Citing DM Technical Notes and Design Documents


### PR DESCRIPTION
The old version was a 404.

Debated whether going through the ls.st shortener or directly linking to
Docushare was the correct approach; decided on the former, because although it
introduces a single point of failure, it also means there's a single place to
update if Docushare moves again.