### PR TITLE
DM-19812: Remove rule on return value policy from pybind11 style guide

### DIFF
--- a/pybind11/how-to.rst
+++ b/pybind11/how-to.rst
@@ -582,8 +582,7 @@ If the symbols are part of the public API then this is typically done by adding 
 Advanced Wrappers
 =================
 
-In this section we are going to look at some more advanced wrapping.
-In particular inheritance and templates
+In this section we are going to look at some more advanced wrapping, in particular inheritance and templates.
 We shall also cover how to add pure Python members to wrapped C++ classes.
 
 We wrap the following two header files from the ``templates`` package, ``ExampleTwo.h``:

--- a/pybind11/how-to.rst
+++ b/pybind11/how-to.rst
@@ -797,6 +797,22 @@ Following :ref:`this rule <style-guide-pybind11-declare-template-wrappers>` we d
 
     (For historical reasons we have a mix of both traditional integer types and defined-size integer types.)
 
+.. _pybind11-special-functions:
+
+Special Functions
+-----------------
+
+By default, pybind11 copies the result of a C++ function call into a new Python object, unless the result is a C-style pointer (in which case it assumes it points to a new object whose memory needs to be managed by Python).
+This behavior is not always safe or appropriate, particularly for references or pointers to object internals.
+pybind11 provides `return value policies <https://pybind11.readthedocs.io/en/stable/advanced/functions.html#return-value-policies>`_ that let developers customize how pybind11 interprets object ownership.
+
+For example, to let Python code change the state of a C++ object through an internal reference:
+
+.. code-block:: cpp
+
+    cls.def("getModifiableInternal", &Class::getModifiableInternal,
+            py::return_value_policy::reference_internal)
+
 .. _pybind11-cross-module-dependencies:
 
 Cross-module dependencies

--- a/pybind11/style.rst
+++ b/pybind11/style.rst
@@ -550,17 +550,6 @@ Wrapping ``__div__`` allows old-style division to work, which should be disallow
 
 The same rule applies for in-place operators:  ``__itruediv__`` and ``__ifloordiv__`` may be defined, but ``__idiv__`` should not.
 
-.. _style-guide-pybind11-internal-data-member-access:
-
-The ``reference_internal`` policy SHALL be used for functions (or properties) giving write access to internal data members
---------------------------------------------------------------------------------------------------------------------------
-
-When a C++ method returns a non-const reference or (smart) pointer to a data member, it SHALL be wrapped with the ``py::return_value_policy::reference_internal`` call policy, even if there is an overload returning a const object of the same type.
-
-When a C++ method returns a const reference or (smart) pointer to a data member (not a new object), and provides no non-const way to access that data member, that method SHALL be wrapped with the ``py::return_value_policy::automatic`` call policy (the default, so no need to specify), to prevent accidental modification of the internal data member (which is a much more serious offence in C++ than Python).
-
-In rare cases, ``py::return_value_policy::reference_internal`` may be used if the expense of copying the object is large and the likelihood of accidental modification is low.
-
 .. _style-guide-pybind11-properties:
 
 All rules from the Python style guide regarding properties SHALL also apply to C++ wrappers


### PR DESCRIPTION
This PR removes the rules on return value policies from the pybind11 style guide, after adding a descriptive section to the pybind11 tutorial.