### PR TITLE
DM-20448: Adopt the default role for code links

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -404,9 +404,8 @@ intersphinx_mapping = {
     'astropy': ('http://docs.astropy.org/en/stable/', None),
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
     'pytest': ('https://pytest.readthedocs.io/en/latest/', None),
-    'pipelines': ('https://pipelines.lsst.io', None),
+    'pipelines': ('https://pipelines.lsst.io/v/weekly/', None),
     'documenteer': ('https://documenteer.lsst.io/', None),
     'sphinx': ('http://www.sphinx-doc.org/en/master/', None),
     'deprecated': ('https://deprecated.readthedocs.io/en/latest/', None),
-    'lsst': ('https://pipelines.lsst.io/v/weekly/', None)
 }

--- a/conf.py
+++ b/conf.py
@@ -100,9 +100,9 @@ exclude_patterns = [
     'restructuredtext/examples',
     '_assets']
 
-# The reST default role (used for this markup: `text`) to use for all
-# documents.
-# default_role = None
+# The reST default role (single back ticks `dict`) cross links to any code
+# object (including Python, but others as well).
+default_role = 'obj'
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 # add_function_parentheses = True

--- a/cpp/clang-format.rst
+++ b/cpp/clang-format.rst
@@ -32,7 +32,7 @@ or Zesty (17.04) commands:
     sudo apt update
     sudo apt install clang-format-5.0
 
-This will install the ``clang-format-5.0`` binary, but will not symlink it to `clang-format`.
+This will install the ``clang-format-5.0`` binary, but will not symlink it to ``clang-format``.
 To create a system-managed symlink ("alternative"), use the following command:
 
 .. code-block:: bash

--- a/cpp/style.rst
+++ b/cpp/style.rst
@@ -2095,8 +2095,8 @@ See :ref:`Rule 3-6 <style-guide-cpp-3-6>` for an almost equivalent Rule.
 
 .. _style-guide-cpp-5-43:
 
-5-43. Implementation-specific globals SHOULD go in namespace `*::detail`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5-43. Implementation-specific globals SHOULD go in namespace ``*::detail``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Sometimes implementation-specific details need to be globally visible (i.e. can't be in the private part of a class, or be declared static or in an anon namespace in a single file).
 For example, the fits i/o code in ``lsst::afw::image`` uses ``boost::gil`` internals but needs to be in a header file included by both :file:`Image.cc` and :file:`Mask.cc`; there are also Image traits classes.
@@ -2703,8 +2703,8 @@ While it is not expected that we will bring the guts of all legacy code in line 
 
 .. _style-guide-cpp-using:
 
-Appendix: On Using `Using`
-==========================
+Appendix: On Using ``using``
+============================
 
 C++ provides the ``using`` keyword for use in declarations and directives relating to namespaces.
 This powerful capability can simplify and reduce the verbosity of code, but it can also lead to reliability and maintainability challenges when the source of non-local names is not obvious.

--- a/cpp/templates.rst
+++ b/cpp/templates.rst
@@ -69,8 +69,8 @@ If you look at :ref:`Foo.h <cpp_template_example_foo_h>` you'll see that there's
 The main features are that an inline member of ``Foo`` needs to be fully specified in :ref:`Foo.h <cpp_template_example_foo_h>` (how else could the compiler inline it?), and also an example of explicit instantiation of a function, rather than a class.
 There should be no surprises.
 
-What about `extern template` and `-no-implicit-templates`?
-==========================================================
+What about ``extern template`` and ``-no-implicit-templates``?
+==============================================================
 
 These code examples didn't use either ``extern template`` or ``-no-implicit-templates``; why not?
 

--- a/pybind11/how-to.rst
+++ b/pybind11/how-to.rst
@@ -566,7 +566,7 @@ Edit ``python/.../SConscript`` to look like this:
 Importing the wrapper
 ---------------------
 
-The Python name for your wrapper module is `exampleOne`.
+The Python name for your wrapper module is ``exampleOne``.
 If the wrapped classes can be returned by a function or unpickled then it is crucial that your module is imported when the package is imported.
 If the symbols are part of the public API then this is typically done by adding the following to your package's main ``__init__.py`` file:
 
@@ -963,7 +963,7 @@ We'll use the ``continueClass`` decorator to reopen the class and add a new meth
             return x + self.someOtherMethod()
 
 
-Both the combined `_tmpl` module and any pure-Python customizations should be lifted into the package in its ``__init__.py``:
+Both the combined ``_tmpl`` module and any pure-Python customizations should be lifted into the package in its ``__init__.py``:
 
 .. code-block:: python
 

--- a/pybind11/style.rst
+++ b/pybind11/style.rst
@@ -68,7 +68,7 @@ Modules and source files
 C++ wrapper code for a package SHOULD go in a module and source file named by adding an underscore prefix to the package name
 -----------------------------------------------------------------------------------------------------------------------------
 
-For example, the Python wrapper module for ``lsst.geom`` should be ``_geom``, defined (at least in part) in a source file `_geom.cc`.
+For example, the Python wrapper module for ``lsst.geom`` should be ``_geom``, defined (at least in part) in a source file ``_geom.cc``.
 
 .. _style-guide-pybind11-cxx-source:
 
@@ -443,7 +443,7 @@ Keyword arguments MAY be provided for non-overloaded functions with two or fewer
 Literals MUST be used for all named arguments
 ----------------------------------------------
 
-The `_a` argument literal from `pybind11::literals` MUST be used for all named arguments (e.g. ``mod.def("f", f, "arg1"_a, "arg2"_a);``).
+The ``_a`` argument literal from ``pybind11::literals`` MUST be used for all named arguments (e.g. ``mod.def("f", f, "arg1"_a, "arg2"_a);``).
 The ``py::arg()`` construct SHALL NOT be used.
 
 .. _style-guide-pybind11-enum-scoping:

--- a/python/style.rst
+++ b/python/style.rst
@@ -647,7 +647,7 @@ Within a module, follow the order:
 ``super`` MAY be used to call parent class methods
 --------------------------------------------------
 
-If you are overriding a method from a parent class, use :py:func:`super()` to call the parent class's method.
+If you are overriding a method from a parent class, use `super` to call the parent class's method.
 For example:
 
 .. code-block:: py
@@ -663,24 +663,24 @@ For example:
 
     C().method(arg)
 
-Using :py:func:`super()` ensures a consistent Method Resolution Order, and prevents inherited methods from being called multiple times.
-In Python 3, :py:func:`super()` does not require naming the class that it is part of, making its use simpler and removing a maintenance issue.
+Using `super` ensures a consistent Method Resolution Order, and prevents inherited methods from being called multiple times.
+In Python 3, `super` does not require naming the class that it is part of, making its use simpler and removing a maintenance issue.
 
 super() and Multiple Inheritance
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In the presence of multiple inheritance (two or more parents, e.g. ``class C(A, B)``), the trickiest issue with the use of :py:func:`super()` is that the class author generally doesn't know a priori which overridden method will be called in what order.
+In the presence of multiple inheritance (two or more parents, e.g. ``class C(A, B)``), the trickiest issue with the use of `super` is that the class author generally doesn't know a priori which overridden method will be called in what order.
 In particular, this means that the calling signature (arguments) for all versions of a method must be compatible.
-As a result, there are a few argument-related caveats about the use of :py:func:`super()` in multiple inheritance hierarchies:
+As a result, there are a few argument-related caveats about the use of `super` in multiple inheritance hierarchies:
 
-* Only pass :py:func:`super()` the exact arguments you received.
-* When you use it on methods whose acceptable arguments can be altered on a subclass via addition of more optional arguments, always accept ``*args``, ``**kwargs``, and call :py:func:`super()` like ``super().currentmethod(arg1, arg2, ..., *args, **kwargs)``. If you don’t do this, document that addition of optional arguments in subclasses is forbidden.
+* Only pass `super` the exact arguments you received.
+* When you use it on methods whose acceptable arguments can be altered on a subclass via addition of more optional arguments, always accept ``*args``, ``**kwargs``, and call `super` like ``super().currentmethod(arg1, arg2, ..., *args, **kwargs)``. If you don’t do this, document that addition of optional arguments in subclasses is forbidden.
 * Do not use positional arguments in ``__init__`` or ``__new__``.  Instead, use keyword args in the declarations, always call them using keywords, and always pass all keywords on, e.g. ``super().__init__(**kwargs)``.
 
-To use :py:func:`super()` with multiple inheritance, all base classes in Python's Method Resolution Order need to use :py:func:`super()`; otherwise the calling chain gets interrupted.
-If your class may be used in multiple inheritance, ensure that all relevant classes use :py:func:`super()` including documenting requirements for subclasses.
+To use `super` with multiple inheritance, all base classes in Python's Method Resolution Order need to use `super`; otherwise the calling chain gets interrupted.
+If your class may be used in multiple inheritance, ensure that all relevant classes use `super` including documenting requirements for subclasses.
 
-For more details, see the :py:func:`super() documentation <super()>`, the `astropy coding guide <http://docs.astropy.org/en/stable/development/codeguide.html#super-vs-direct-calling>`__, and `this article from Raymond Hettinger <https://rhettinger.wordpress.com/2011/05/26/super-considered-super/>`__.
+For more details, see the `super documentation <super>`, the `astropy coding guide <http://docs.astropy.org/en/stable/development/codeguide.html#super-vs-direct-calling>`__, and `this article from Raymond Hettinger <https://rhettinger.wordpress.com/2011/05/26/super-considered-super/>`__.
 
 .. _style-guide-py-comparisons:
 
@@ -804,7 +804,7 @@ To test for inclusion use ``in``:
     if key in myDict:
         pass
 
-This is preferred over :meth:`~dict.keys`. Use :meth:`~dict.keys` when storing the keys for later access:
+This is preferred over `~dict.keys`. Use `~dict.keys` when storing the keys for later access:
 
 .. code-block:: py
 
@@ -817,7 +817,7 @@ where ``list`` ensures that a view or iterator is not being retained.
 The ``subprocess`` module SHOULD be used to spawn processes
 -----------------------------------------------------------
 
-Use the :py:mod:`subprocess` module to spawn processes.
+Use the `subprocess` module to spawn processes.
 
 .. _style-guide-py-lambda:
 
@@ -825,21 +825,21 @@ Use the :py:mod:`subprocess` module to spawn processes.
 -----------------------------
 
 Avoid the use of `lambda <https://docs.python.org/3/reference/expressions.html#lambda>`__.
-You can almost always write clearer code by using a named function or using the :py:mod:`functools` module to wrap a function.
+You can almost always write clearer code by using a named function or using the `functools` module to wrap a function.
 
 .. _style-guide-py-set:
 
 The ``set`` type SHOULD be used for unordered collections
 ---------------------------------------------------------
 
-Use the :py:class:`set` type for unordered collections of objects.
+Use the `set` type for unordered collections of objects.
 
 .. _style-guide-py-argparse:
 
 The ``argparse`` module SHOULD be used for command-line scripts
 ---------------------------------------------------------------
 
-Use the :py:mod:`argparse` module for command-line scripts.
+Use the `argparse` module for command-line scripts.
 
 Command line tasks for pipelines should use :lclass:`lsst.pipe.base.ArgumentParser` instead.
 

--- a/python/testing.rst
+++ b/python/testing.rst
@@ -241,8 +241,6 @@ Inheriting from `lsst.utils.tests.TestCase` rather than `unittest.TestCase` enab
 `lsst.utils.tests.TestCase.assertFloatsNotEqual`
    Asserts that floating point scalars and/or arrays are not equal.
 
-Note that `~lsst.utils.tests.TestCase.assertClose` and `~lsst.utils.tests.TestCase.assertNotClose` methods have been deprecated by the above methods.
-
 Additionally, :ref:`lsst.afw.coord <pipelines:lsst.afw.coord>`, :ref:`lsst.afw.geom <pipelines:lsst.afw.geom>`, and :ref:`lsst.afw.image <pipelines:lsst.afw.image>` provides additional asserts that get loaded into `lsst.utils.tests.TestCase` when the associated module is loaded.
 These include methods for `Coords`_, `Geom (Angles, Pairs, Boxes)`_, and `Images`_, such as:
 
@@ -353,7 +351,7 @@ For example,
 Legacy Test Code
 ================
 
-If you have legacy DM `unittest` ``suite``-based code (code that sets up a `unittest.TestSuite` object by listing specific test classes and that uses `lsst.utils.tests.run` rather than `unittest.main`), please refer to tech note `SQR-012`_ for porting instructions.
+If you have legacy DM `unittest` ``suite``-based code (code that sets up a `unittest.TestSuite` object by listing specific test classes and that uses ``lsst.utils.tests.run`` rather than `unittest.main`), please refer to tech note `SQR-012`_ for porting instructions.
 
 
 .. _`Coords`: http://doxygen.lsst.codes/stack/doxygen/x_masterDoxyDoc/x_masterDoxyDoc/namespacelsst_1_1afw_1_1coord_1_1utils.html

--- a/python/testing.rst
+++ b/python/testing.rst
@@ -9,7 +9,7 @@ Python Unit Testing
 
 This page provides technical guidance to developers writing unit tests for DM's Python code base.
 See :doc:`/coding/unit-test-policy` for an overview of LSST Stack testing.
-LSST tests should be written using the :mod:`unittest` framework, with default test discovery, and should support being run using the `pytest`_ test runner as well as from the command line.
+LSST tests should be written using the `unittest` framework, with default test discovery, and should support being run using the `pytest`_ test runner as well as from the command line.
 If you want to jump straight to a full example of the standard LSST Python testing boilerplate without reading the background, read the :ref:`section on memory testing <py-test-mem>` later in this document.
 
 .. _SQR-012: http://sqr-012.lsst.io
@@ -18,7 +18,7 @@ If you want to jump straight to a full example of the standard LSST Python testi
 Introduction to ``unittest``
 ============================
 
-This document will not attempt to explain full details of how to use :mod:`unittest` but instead shows common scenarios encountered in the LSST codebase.
+This document will not attempt to explain full details of how to use `unittest` but instead shows common scenarios encountered in the LSST codebase.
 
 A simple :mod:`unittest` example is shown below:
 
@@ -29,16 +29,16 @@ A simple :mod:`unittest` example is shown below:
 The important things to note in this example are:
 
 * Test file names must begin with ``test_`` to allow `pytest`_ to automatically detect them without requiring an explicit test list, which can be hard to maintain and can lead to missed tests.
-* If the test is being executed using :command:`python` from the command line the :py:func:`unittest.main` call performs the test discovery and executes the tests, setting exit status to non-zero if any of the tests fail.
+* If the test is being executed using :command:`python` from the command line the `unittest.main` call performs the test discovery and executes the tests, setting exit status to non-zero if any of the tests fail.
 * Test classes are executed in the order in which they appear in the test file.
   In this case the tests in ``DemoTestCase1`` will be executed before those in ``DemoTestCase2``.
-* Test classes must, ultimately, inherit from :class:`unittest.TestCase` in order to be discovered, and it is :ref:`recommended <py-utils-tests>` that :lclass:`lsst.utils.tests.TestCase` be used as the base class when :lmod:`~lsst.afw` objects are involved.
+* Test classes must, ultimately, inherit from `unittest.TestCase` in order to be discovered, and it is :ref:`recommended <py-utils-tests>` that `lsst.utils.tests.TestCase` be used as the base class when :lmod:`~lsst.afw` objects are involved.
   The tests themselves must be methods of the test class with names that begin with ``test``.
   All other methods and classes will be ignored by the test system but can be used by tests.
-* Specific test asserts, such as :meth:`~unittest.TestCase.assertGreater`, :meth:`~unittest.TestCase.assertIsNone` or :meth:`~unittest.TestCase.assertIn`, should be used wherever possible.
+* Specific test asserts, such as `~unittest.TestCase.assertGreater`, `~unittest.TestCase.assertIsNone` or `~unittest.TestCase.assertIn`, should be used wherever possible.
   It is always better to use a specific assert because the error message will contain more useful detail and the intent is more obvious to someone reading the code.
-  Only use :meth:`~unittest.TestCase.assertTrue` or :meth:`~unittest.TestCase.assertFalse` if you are checking a boolean value, or a complex statement that is unsupported by other asserts.
-* When testing that an exception is raised always use :meth:`~unittest.TestCase.assertRaises` as a context manager, as shown in line 10 of the above example.
+  Only use `~unittest.TestCase.assertTrue` or `~unittest.TestCase.assertFalse` if you are checking a boolean value, or a complex statement that is unsupported by other asserts.
+* When testing that an exception is raised always use `~unittest.TestCase.assertRaises` as a context manager, as shown in line 10 of the above example.
 * If a test method completes, the test passes; if it throws an uncaught exception the test has failed.
 
 Supporting Pytest
@@ -51,10 +51,10 @@ All LSST products that are built using :command:`scons` will execute Python test
 `pytest`_ provides a much richer execution and reporting environment for tests and can be used to run multiple test files together.
 
 The `pytest`_ scheme for discovering tests inside Python modules is much more flexible than that provided by :mod:`unittest`, but LSST test files should not take advantage of that flexibility as it can lead to inconsistency in test reports that depend on the specific test runner, and it is required that an individual test file can be executed by running it directly with :command:`python`.
-In particular, care must be taken not to have free functions that use a ``test`` prefix or non-\ :class:`~unittest.TestCase` test classes that are named with a ``Test`` prefix in the test files.
+In particular, care must be taken not to have free functions that use a ``test`` prefix or non-\ `~unittest.TestCase` test classes that are named with a ``Test`` prefix in the test files.
 
 .. note::
-  When :command:`pytest` is run by :command:`scons` full warnings are reported, including :py:class:`DeprecationWarning`.
+  When :command:`pytest` is run by :command:`scons` full warnings are reported, including `DeprecationWarning`.
   Previously these warnings were hidden in the test output but now they are more obvious, allowing you to fix any problems early.
 
 The tests/SConscript file
@@ -81,7 +81,7 @@ Automatic test discovery is preferred as this ensures that there is no differenc
 Running tests standalone
 ------------------------
 
-``pySingles`` is an optional argument to the :lmeth:`~lsst.sconsUtils.scripts.BasicSConscript.tests` method that can be used for the rare cases where a test must be run standalone and not with other test files in a shared process.
+``pySingles`` is an optional argument to the `~lsst.sconsUtils.scripts.BasicSConscript.tests` method that can be used for the rare cases where a test must be run standalone and not with other test files in a shared process.
 
 .. code-block:: python
 
@@ -137,7 +137,7 @@ Test Skipping and Expected Failures
 
 When writing tests it is important that tests are skipped using the proper :mod:`unittest` :ref:`skipping framework <python:unittest-skipping>` rather than returning from the test early.
 :mod:`unittest` supports skipping of individual tests and entire classes using decorators or skip exceptions.
-LSST code sometimes raises skip exceptions in :meth:`~unittest.TestCase.setUp` or :meth:`~unittest.TestCase.setUpClass` class methods.
+LSST code sometimes raises skip exceptions in `~unittest.TestCase.setUp` or `~unittest.TestCase.setUpClass` class methods.
 It is also possible to indicate that a particular test is expected to fail, being reported as an error if the test unexpectedly passes.
 Expected failures can be used to write test code that triggers a reported bug before the fix to the bug has been implemented and without causing the continuous integration system to die.
 One of the primary advantages of using a modern test runner such as `pytest`_ is that it is very easy to generate machine-readable pass/fail/skip/xfail statistics to see how the system is evolving over time, and it is also easy to enable code coverage.
@@ -194,7 +194,7 @@ Using a shared base class
 
 For some tests it is helpful to provide a base class and then share it amongst multiple test classes that are configured with different attributes.
 If this is required, be careful to not have helper functions prefixed with ``test``.
-Do not have the base class named with a ``Test`` prefix and ensure it does not inherit from :class:`~unittest.TestCase`; if you do, `pytest`_ will attempt to find tests inside it and will issue a warning if none can be found.
+Do not have the base class named with a ``Test`` prefix and ensure it does not inherit from `~unittest.TestCase`; if you do, `pytest`_ will attempt to find tests inside it and will issue a warning if none can be found.
 Historically LSST code has dealt with this by creating a test suite that only includes the classes to be tested, omitting the base class.
 This does not work in a `pytest`_ environment.
 
@@ -203,7 +203,7 @@ Consider the following test code:
 .. literalinclude:: examples/test_baseclass.py
    :language: python
 
-which inherits from the helper class and :class:`unittest.TestCase` and runs a single test without attempting to run any tests in ``BaseClass``.
+which inherits from the helper class and `unittest.TestCase` and runs a single test without attempting to run any tests in ``BaseClass``.
 
 .. code-block:: text
 
@@ -222,26 +222,28 @@ which inherits from the helper class and :class:`unittest.TestCase` and runs a s
 LSST Utility Test Support Classes
 =================================
 
-:lmod:`lsst.utils.tests` provides several helpful functions and classes for writing Python tests that developers should make use of.
+`lsst.utils.tests`__ provides several helpful functions and classes for writing Python tests that developers should make use of.
+
+.. __: https://pipelines.lsst.io/v/weekly/modules/lsst.utils/index.html#lsst-utils-tests-module
 
 .. _py-utils-tests:
 
 Special Asserts
 ---------------
 
-Inheriting from :lclass:`lsst.utils.tests.TestCase` rather than :class:`unittest.TestCase` enables new asserts that are useful for doing element-wise comparison of two floating-point :mod:`numpy`-like arrays or scalars.
+Inheriting from `lsst.utils.tests.TestCase` rather than `unittest.TestCase` enables new asserts that are useful for doing element-wise comparison of two floating-point `numpy`-like arrays or scalars.
 
-`lsst.utils.tests.TestCase.assertFloatsAlmostEqual`_
+`lsst.utils.tests.TestCase.assertFloatsAlmostEqual`
    Asserts that floating point scalars and/or arrays are equal within the specified tolerance.
-   The default tolerance is significantly tighter than the tolerance used by :meth:`unittest.TestCase.assertAlmostEqual` or :func:`numpy.testing.assert_almost_equal`; if you are replacing either of those methods you may have to specify ``rtol`` and/or ``atol`` to prevent failing asserts.
-`lsst.utils.tests.TestCase.assertFloatsEqual`_
+   The default tolerance is significantly tighter than the tolerance used by `unittest.TestCase.assertAlmostEqual` or `numpy.testing.assert_almost_equal`; if you are replacing either of those methods you may have to specify ``rtol`` and/or ``atol`` to prevent failing asserts.
+`lsst.utils.tests.TestCase.assertFloatsEqual`
    Asserts that floating point scalars and/or arrays are identically equal.
-`lsst.utils.tests.TestCase.assertFloatsNotEqual`_
+`lsst.utils.tests.TestCase.assertFloatsNotEqual`
    Asserts that floating point scalars and/or arrays are not equal.
 
-Note that :lmeth:`~lsst.utils.tests.TestCase.assertClose` and :lmeth:`~lsst.utils.tests.TestCase.assertNotClose` methods have been deprecated by the above methods.
+Note that `~lsst.utils.tests.TestCase.assertClose` and `~lsst.utils.tests.TestCase.assertNotClose` methods have been deprecated by the above methods.
 
-Additionally, :lmod:`~lsst.afw` provides additional asserts that get loaded into :lclass:`lsst.utils.tests.TestCase` when the associated module is loaded.
+Additionally, :ref:`lsst.afw.coord <pipelines:lsst.afw.coord>`, :ref:`lsst.afw.geom <pipelines:lsst.afw.geom>`, and :ref:`lsst.afw.image <pipelines:lsst.afw.image>` provides additional asserts that get loaded into `lsst.utils.tests.TestCase` when the associated module is loaded.
 These include methods for `Coords`_, `Geom (Angles, Pairs, Boxes)`_, and `Images`_, such as:
 
 :lmeth:`~lsst.afw.coord.utils.assertCoordsNearlyEqual`
@@ -276,10 +278,10 @@ The file is reproduced here:
 
 The ``EXECUTABLES`` variable can be a tuple containing the names of the executables to be run (relative to the directory containing the test file).
 ``None`` indicates that the test script should discover the executables in the same directory as that containing the test file.
-The call to :lmeth:`~lsst.utils.tests.ExecutablesTestCase.create_executable_tests` initiates executable discovery and creates a test for each executable that is found.
+The call to `~lsst.utils.tests.ExecutablesTestCase.create_executable_tests` initiates executable discovery and creates a test for each executable that is found.
 
 In some cases an explicit test has to be written either because some precondition has to be met before the test will stand a chance of running or because some arguments have to be passed to the executable.
-To support this the :lmeth:`~lsst.utils.tests.ExecutableTestCase.assertExecutable` method is available:
+To support this the `~lsst.utils.tests.ExecutablesTestCase.assertExecutable` method is available:
 
 .. code-block:: python
 
@@ -302,11 +304,11 @@ Memory and file descriptor leak testing
 
 .. _py-test-mem:
 
-:lclass:`lsst.utils.tests.MemoryTestCase` is used to detect memory leaks in C++ objects and leaks in file descriptors.
-:lclass:`~lsst.utils.tests.MemoryTestCase` should be used in *all* test files where :lmod:`~lsst.utils` is in the dependency chain, even if C++ code is not explicitly referenced.
+`lsst.utils.tests.MemoryTestCase` is used to detect memory leaks in C++ objects and leaks in file descriptors.
+`~lsst.utils.tests.MemoryTestCase` should be used in *all* test files where :lmod:`~lsst.utils` is in the dependency chain, even if C++ code is not explicitly referenced.
 
 This example shows the basic structure of an LSST Python unit test module,
-including :lclass:`~lsst.utils.tests.MemoryTestCase` (the highlighted lines indicate the memory testing modifications):
+including `~lsst.utils.tests.MemoryTestCase` (the highlighted lines indicate the memory testing modifications):
 
 .. literalinclude:: examples/test_runner_example.py
    :linenos:
@@ -331,10 +333,10 @@ which ends up running the single specified test plus the two running as part of 
 
    =========================== 3 passed in 0.28 seconds ===========================
 
-Note that :lclass:`~lsst.utils.tests.MemoryTestCase` must always be the
+Note that `~lsst.utils.tests.MemoryTestCase` must always be the
 final test suite.
-For the memory test to function properly the :lfunc:`lsst.utils.tests.init()` function must be invoked before any of the tests in the class are executed.
-Since LSST test scripts are required to run properly from the command-line and when called from within `pytest`_, the :lfunc:`~lsst.utils.tests.init()` function has to be in the file twice: once in the :ref:`setup_module <pytest:xunitsetup>` function that is called by `pytest`_ whenever a test module is loaded (`pytest`_ will not use the ``__main__`` code path), and also just before the call to :func:`unittest.main()` call to handle being called with :command:`python`.
+For the memory test to function properly the `lsst.utils.tests.init` function must be invoked before any of the tests in the class are executed.
+Since LSST test scripts are required to run properly from the command-line and when called from within `pytest`_, the `~lsst.utils.tests.init` function has to be in the file twice: once in the :ref:`setup_module <pytest:xunitsetup>` function that is called by `pytest`_ whenever a test module is loaded (`pytest`_ will not use the ``__main__`` code path), and also just before the call to `unittest.main` call to handle being called with :command:`python`.
 
 Unicode
 =======
@@ -351,12 +353,9 @@ For example,
 Legacy Test Code
 ================
 
-If you have legacy DM :mod:`unittest` ``suite``-based code (code that sets up a :class:`unittest.TestSuite` object by listing specific test classes and that uses :lfunc:`lsst.utils.tests.run` rather than :func:`unittest.main`), please refer to tech note `SQR-012`_ for porting instructions.
+If you have legacy DM `unittest` ``suite``-based code (code that sets up a `unittest.TestSuite` object by listing specific test classes and that uses `lsst.utils.tests.run` rather than `unittest.main`), please refer to tech note `SQR-012`_ for porting instructions.
 
 
-.. _`lsst.utils.tests.TestCase.assertFloatsAlmostEqual`: http://doxygen.lsst.codes/stack/doxygen/x_masterDoxyDoc/namespacelsst_1_1utils_1_1tests.html#a09ee2482a2e8d71e8612c0378f4286fc
-.. _`lsst.utils.tests.TestCase.assertFloatsEqual`: http://doxygen.lsst.codes/stack/doxygen/x_masterDoxyDoc/namespacelsst_1_1utils_1_1tests.html#a0e354bcea6ba8c11238882ede5058c03
-.. _`lsst.utils.tests.TestCase.assertFloatsNotEqual`: http://doxygen.lsst.codes/stack/doxygen/x_masterDoxyDoc/x_masterDoxyDoc/namespacelsst_1_1utils_1_1tests.html#a4fc68518d134e3656499898653a3bce3
 .. _`Coords`: http://doxygen.lsst.codes/stack/doxygen/x_masterDoxyDoc/x_masterDoxyDoc/namespacelsst_1_1afw_1_1coord_1_1utils.html
 .. _`Geom (Angles, Pairs, Boxes)`: http://doxygen.lsst.codes/stack/doxygen/x_masterDoxyDoc/namespacelsst_1_1afw_1_1geom_1_1utils.html
 .. _`Images`: http://doxygen.lsst.codes/stack/doxygen/x_masterDoxyDoc/x_masterDoxyDoc/namespacelsst_1_1afw_1_1image_1_1test_utils.html

--- a/stack/deprecating-interfaces.rst
+++ b/stack/deprecating-interfaces.rst
@@ -36,7 +36,7 @@ Triggering such a warning does not cause a test failure.
 Python Deprecation
 ==================
 
-If you need to deprecate a class or function, import the :py:func:`~deprecated.sphinx.deprecated` decorator::
+If you need to deprecate a class or function, import the `~deprecated.sphinx.deprecated` decorator::
 
    from deprecated.sphinx import deprecated
 
@@ -60,12 +60,12 @@ Class and static methods should be decorated in the order given here::
 The reason string should include the replacement API when available or explain why there is no replacement.
 The reason string will be automatically added to the docstring for the class or function; there is no need to change that.
 You do not need to specify the optional version argument to the decorator since deprecation decorators are typically not added in advance of when the deprecation actually begins.
-Since our end users tend to be developers or at least may call APIs directly from notebooks, we will treat our APIs as end-user features and use ``category=FutureWarning`` instead of the default :py:class:`DeprecationWarning`, which is primarily for Python developers. Do not use :py:class:`PendingDeprecationWarning`.
+Since our end users tend to be developers or at least may call APIs directly from notebooks, we will treat our APIs as end-user features and use ``category=FutureWarning`` instead of the default `DeprecationWarning`, which is primarily for Python developers. Do not use `PendingDeprecationWarning`.
 
 pybind11 Deprecation
 ====================
 
-A deprecated pybind11-wrapped function must be rewrapped in pure Python using the :py:func:`lsst.utils.deprecate_pybind11` function, which defaults to ``category=FutureWarning``::
+A deprecated pybind11-wrapped function must be rewrapped in pure Python using the `lsst.utils.deprecate_pybind11` function, which defaults to ``category=FutureWarning``::
 
    from lsst.utils.deprecated import deprecate_pybind11
    ExposureF.getCalib = deprecate_pybind11(ExposureF.getCalib,

--- a/stack/logging.rst
+++ b/stack/logging.rst
@@ -49,8 +49,8 @@ For example:
    logger.infof("This is information about the star selector algorithm execution. {}", 3.14)
 
 In Python, two string formatting options can be used for log messages.
-The standard methods, such as :lmod:`~lsst.log.info` and :lmod:`~lsst.log.warn`, use a ``%``-format string in the message and pass in additional arguments containing variable information, which :lmod:`lsst.log` will internally merge into the message string with ``%`` formatting if the log record is to be printed.
-Another set of methods with a trailing ``f``, for example :lmod:`~lsst.log.infof` and :lmod:`~lsst.log.warnf`, can use :meth:`~str.format` string interpolation using curly braces.
+The standard methods, such as :lfunc:`~lsst.log.info` and :lfunc:`~lsst.log.warn`, use a ``%``-format string in the message and pass in additional arguments containing variable information, which :lfunc:`lsst.log` will internally merge into the message string with ``%`` formatting if the log record is to be printed.
+Another set of methods with a trailing ``f``, for example :lfunc:`~lsst.log.infof` and :lfunc:`~lsst.log.warnf`, can use `~str.format` string interpolation using curly braces.
 
 To specify the threshold or the lowest-severity log messages a logger handles, :lmeth:`setLevel` can be used:
 

--- a/stack/lsstsw.rst
+++ b/stack/lsstsw.rst
@@ -33,7 +33,7 @@ This will:
 - Download and install `EUPS`_ in :file:`./eups`;
 - Make an empty stack directory in :file:`./stack`, with a default
   :file:`manifest.remap`;
-- Download and install a copy of `etc/repos.yaml` from `lsst/repos`;
+- Download and install a copy of ``etc/repos.yaml`` from ``lsst/repos``;
 - Run :command:`git clone lsst_build master`
 - Run :command:`git clone versiondb master`
 
@@ -255,12 +255,12 @@ Updating your EUPS version
 ==========================
 
 In order to install a new version of EUPS, first check your current
-installed version with the '-V' flag::
+installed version with the ``-V`` flag::
 
     % eups -V
 
 Next, define the relevant environment variable as so: :command:`export
-EUPS_VERSION=x.y.z` (where `x.y.z` is the version you would like to
+EUPS_VERSION=x.y.z` (where ``x.y.z`` is the version you would like to
 install).  Then install the new EUPS version by changing to your
 ${LSSTSW} directory and doing::
 
@@ -269,13 +269,11 @@ ${LSSTSW} directory and doing::
 there.  This will install that version of EUPS and set your default
 version to it, henceforth.
 
-Older versions will still be available under ${LSSTSW}/eups, and you
+Older versions will still be available under ``${LSSTSW}/eups``, and you
 can switch back to those by simply setting again :command:`export
 EUPS_VERSION=a.b.c`, opening a new terminal window, and then executing
-`source $LSSTSW/bin/setup.sh` in that window to make `a.b.c` the
+``source $LSSTSW/bin/setup.sh`` in that window to make ``a.b.c`` the
 default version.  Opening any new terminal window from here will keep
 using this version, also.
 
-The simplest place to find all available versions of EUPS is by looking at `this page`_ on github.
-
-.. _this page: https://github.com/RobertLuptonTheGood/eups/releases
+The simplest place to find all available versions of EUPS is by `looking at GitHub <https://github.com/RobertLuptonTheGood/eups/releases>`__.

--- a/stack/package-homepage-topic-type.rst
+++ b/stack/package-homepage-topic-type.rst
@@ -89,7 +89,7 @@ Contributing section
 ====================
 
 This section puts the package in context as an open source development project.
-The `template <package-homepage-template>` seeds this section with links to the GitHub repository for the package and a ticket search with the package's corresponding Jira component (if the package does not have a Jira component, request one in `#dm-square`_).
+The `template <package-homepage-template>`__ seeds this section with links to the GitHub repository for the package and a ticket search with the package's corresponding Jira component (if the package does not have a Jira component, request one in `#dm-square`_).
 
 If there is documentation describing how to develop (contribute) to the package, as opposed to using the package, you should link to those topics with a `toctree`_ in this section.
 

--- a/stack/packaging-third-party-eups-dependencies.rst
+++ b/stack/packaging-third-party-eups-dependencies.rst
@@ -242,7 +242,7 @@ Testing the package
 
 If you've created a new external package or updated an existing package, you need
 to test whether the new package builds and works. From within
-:file:`build/yourPackage` (add `-r` to build in the current directory, which
+:file:`build/yourPackage` (add ``-r`` to build in the current directory, which
 is effectively how Jenkins does it, instead using :file:`_eupspkg/`):
 
 - :command:`rm -r _eupspkg`

--- a/stack/task-topic-type.rst
+++ b/stack/task-topic-type.rst
@@ -16,7 +16,7 @@ The task topic file template is available in the `lsst/templates repository`_.
 
 .. note::
 
-   The `task topic file template` sets technical details like names and labels for sections, and any boilerplate autodocumenting directives.
+   The `task topic file template`_ sets technical details like names and labels for sections, and any boilerplate autodocumenting directives.
    Starting from the template is the best way to follow the task topic standard.
 
 .. _task topic file template:
@@ -114,7 +114,7 @@ Processing summary section
 The "Processing summary" section outlines the algorithm that the task implements.
 Like the context paragraph above it, the "Processing summary" should be brief and highly scannable.
 The reader should be able to quickly grasp what the task does through this section.
-For algorithmic or usage details, refer the reader to the ref:`"In depth" section <task-topic-indepth>`.
+For algorithmic or usage details, refer the reader to the :ref:`"In depth" section <task-topic-indepth>`.
 
 In most cases you can express the algorithm as an enumerated list.
 Introduce the list with a sentence like this:

--- a/work/project-planning.rst
+++ b/work/project-planning.rst
@@ -49,7 +49,7 @@ during Construction, the following process has been used.
 #. At the start of each 6-month period (aka each new Winter or Summer Release)
    each DM Cost Account Manager (T/CAM) interviews the institution team and
    creates a very detailed work plan, with individual activity granularity from 1
-   to 3 months (see the `T/CAM Guide`). Further, each activity is divided into
+   to 3 months (see the `T/CAM Guide`_). Further, each activity is divided into
    steps of 2 - 20 days effort. This plan is known as a Release Plan. This
    process is done via the Agile Process, including backlog and sprint meetings,
    interactive communications, and design reviews. This process is accomplished


### PR DESCRIPTION
This PR sets the default role (text in single backticks) to be the `:obj:` role. This provides a flexible way to generate links to any Sphinx API reference, and any supported language, just by wrapping the API name in single backticks. This replaces the need for spelling out roles like `:py:meth:` or even `:meth:`.

Specifically, this PR:

1. Configured the default role
2. Fixed earlier usage of the default role that was accidental
3. Converted content, where applicable, to use the default role.

The PR also switches the intersphinx link for pipelines.lsst.io to use the weekly edition, and removes a duplicate entry.

Preview: https://developer.lsst.io/v/DM-20448/