### PR TITLE
DM-20736: Update to documenteer 0.5.x, pytest intersphinx

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -403,7 +403,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'astropy': ('http://docs.astropy.org/en/stable/', None),
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
-    'pytest': ('https://docs.pytest.org/en/latest/', None),
+    'pytest': ('https://pytest.readthedocs.io/en/latest/', None),
     'pipelines': ('https://pipelines.lsst.io', None),
     'documenteer': ('https://documenteer.lsst.io/', None),
     'sphinx': ('http://www.sphinx-doc.org/en/master/', None),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 sphinx_rtd_theme==0.2.0
-documenteer==0.3.0
+documenteer>=0.5.1,<0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sphinx_rtd_theme==0.2.0
+sphinx_rtd_theme>=0.4.3,<0.5.0
 documenteer>=0.5.1,<0.6.0


### PR DESCRIPTION
- Update documenteer to 0.5.x to resolve the docutils issue described in https://github.com/lsst-sqre/documenteer/pull/65
- Temporarily update the intersphinx link for pytest as described in https://github.com/pytest-dev/pytest/issues/5641 (the process of getting pytest.org back up is taking longer than anticipated).
- Update the sphinx_rtd_theme to 0.4.x to get their latest design updates and fixes

https://developer.lsst.io/v/DM-20736/index.html