### PR TITLE
DM-21117: Feature @sqrbot-jr for creating files and technotes from templates

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -130,6 +130,12 @@ if on_rtd:
 else:
     todo_include_todos = True
 
+# Common substitutions and link targets available in every document
+rst_epilog = """
+.. |sqrbot| replace:: `@sqrbot-jr <https://slack.com/app_redirect?app=AF2U6ADV3&team=T06D204F2>`__
+.. |dmw-sqrbot| replace:: `direct message with @sqrbot-jr <https://slack.com/app_redirect?app=AF2U6ADV3&team=T06D204F2>`__
+"""
+
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/legal/copyright-overview.rst
+++ b/legal/copyright-overview.rst
@@ -151,7 +151,18 @@ For example:
 
 The :file:`COPYRIGHT` file does not contain any other content.
 
-`A template <https://github.com/lsst/templates/tree/master/file_templates/copyright>`_ for COPYRIGHT files is available.
+.. tip::
+
+   **Create a COPYRIGHT file from Slack.**
+   Open a |dmw-sqrbot| and type:
+
+   .. code-block:: text
+
+      create file
+
+   Then select **General > COPYRIGHT file**.
+
+`A template <https://github.com/lsst/templates/tree/master/file_templates/copyright>`_ for COPYRIGHT files is also available.
 
 Background
 ----------

--- a/project-docs/technotes.rst
+++ b/project-docs/technotes.rst
@@ -5,6 +5,7 @@ Technotes for Stand-Alone Technical Documentation
 Technotes are a way for Data Management team members to write standalone documents that are native to the web, can be cited in literature, and are easy to write, publish, and update.
 You can write with either our reStructuredText or LaTeX templates.
 All technotes are developed on GitHub and published with `LSST the Docs`_.
+You can find a listing of available technotes at `www.lsst.io <https://www.lsst.io>`__.
 
 .. _LSST the Docs: https://sqr-006.lsst.io
 
@@ -70,50 +71,45 @@ Technote series
 Create a technote
 =================
 
-Follow these steps to create a new technote:
+Creating a new technote is easy and takes just a moment.
+In Slack, open a |dmw-sqrbot| and type:
 
-1. Identify the next-available technote handle in the series you are creating a technote for.
-   You can do this by searching the series's GitHub organization.
+.. code-block:: text
 
-   For example, to identify the next-available DMTN repository, search the `lsst-dm <https://github.com/lsst-dm>`__ organization:
+   create project
 
-   https://github.com/search?o=desc&q=org%3Alsst-dm+dmtn-&s=updated&type=Repositories
+From the drop-down, select **Documents > Technote (reStructuredText)** or **(LaTeX)** depending on the format you wish to work in.
+Once you select the template type and fill in the form on Slack, the bot will create and configure the technote on GitHub.
+Watch for Slack messages from the bot about the technote's GitHub repository, including a link to a pull request.
 
-   For discussion, the highest-numbered repository in the search result might be ``https://github.com/lsst-dm/dmtn-100``.
-   Try to go to the *next* repository, ``https://github.com/lsst-dm/dmtn-101``:
+.. important::
 
-   - If the page is a 404 (Not Found), that URL corresponds to the next-available repository.
+   You need to merge the bot's pull request in order for your technote to appear on the web.
 
-   - If the page exists, keep incrementing the serial number in the URL until you find a page that is unavailable (try visiting ``https://github.com/lsst-dm/dmtn-102``, ``https://github.com/lsst-dm/dmtn-103``, and so on).
+Once the initial configuration pull request is merged, any time you push to GitHub your technote will be republished at its ``lsst.io`` site.
+Pushes to the ``master`` branch update your technote's main page, while updates to other branches update preview editions behind the ``/v/`` URL path.
+Click on the **Switch editions** or **Change version** link from your published technote to get links for other editions.
 
-2. `Create a GitHub repository <https://help.github.com/articles/creating-a-new-repository/>`_ in the GitHub organization corresponding to the handle you identified in the previous step.
-   Leave the repo empty — don't seed it with a ``.gitignore`` or ``README``.
+.. _technote-latex:
 
-3. Create a Git repository from a template.
-   Which template you use depends on the technote's format:
+Working with LaTeX-formatted technotes
+======================================
 
-   - If you are creating a reStructuredText-based technote that is built with Sphinx into HTML, run the following commands in a shell:
+LaTeX-formatted technotes use the ``lsstdoc`` class.
+The `lsst-texmf documentation <https://lsst-texmf.lsst.io/lsstdoc.html>`__ explains how to write ``lsstdoc``-based documents.
 
-     .. code-block:: sh
+.. _technote-rst:
 
-        git clone https://github.com/lsst/templates
-        pip install -r templates/requirements.txt
-        templatekit make technote_rst
+Working with reStructuredText-formatted technotes
+=================================================
 
-   - If you are creating a LaTeX-formatted technote that is built into a PDF, follow the `lsst-texmf documentation <https://lsst-texmf.lsst.io/templates/document.html>`_
-
-   Be sure to commit and push the new technote to GitHub.
-   When you create a new repository on GitHub, the repository's initial GitHub homepage provides instructions on how to push to GitHub.
-
-4. Message the `#dm-docs <https://lsstc.slack.com/archives/dm-docs>`__ Slack channel so that the Travis integration for your technote can be activated.
-
-   Don't wait to configure your document's deployment.
-   By configuring your technote's deployment early on, it's easier for collaborators to view your content.
+See the :doc:`/restructuredtext/style` for a primer on writing reStructuredText.
+The sections below deal with specific issues for technote projects.
 
 .. _technote-rst-bib:
 
 Using bibliographies in reStructuredText technotes
-==================================================
+--------------------------------------------------
 
 The lsst-texmf project includes `shared BibTeX bibliographic databases <https://lsst-texmf.lsst.io/lsstdoc.html#bibliographies>`_.
 You can also use these bibliographies from reStructuredText technotes.
@@ -149,7 +145,7 @@ In-text citations are numbered, not author-year style.
 .. _technote-rst-metadata:
 
 Editing metadata in reStructuredText technotes
-==============================================
+----------------------------------------------
 
 ReStructuredText-format technotes use a :file:`metadata.yaml` in their repositories to describe attributes like the document's title, author list, and abstract.
 To change the technote's title or author list, for example, commit a change to the :file:`metadata.yaml` file.

--- a/stack/argparse-script-topic-type.rst
+++ b/stack/argparse-script-topic-type.rst
@@ -18,7 +18,16 @@ This topic type is a specialization of the :doc:`script-topic-type` that lets yo
 Starter template
 ================
 
-The argparse-based script topic template is available in the `lsst/templates repository`_.
+Create a new argparse-based script topic from Slack.\ [#template]_
+Open a |dmw-sqrbot| and type:
+
+.. code-block:: text
+
+   create file
+
+Then select **Science Pipelines documentation > Script topic (argparse)**.
+
+.. [#template] The argparse-based script topic template is maintained in the `lsst/templates repository`_.
 
 .. _lsst/templates repository: https://github.com/lsst/templates/tree/master/file_templates/argparse_script_topic
 

--- a/stack/config-topic-type.rst
+++ b/stack/config-topic-type.rst
@@ -14,14 +14,17 @@ This page describes how to document config classes like ``ColortermLibrary``.
 Starter template
 ================
 
-The config topic file template is available in the `lsst/templates repository`_.
+Create a new config topic from Slack.\ [#template]_
+Open a |dmw-sqrbot| and type:
 
-.. note::
+.. code-block:: text
 
-   The `config topic file template`_ sets technical details like labels for sections, names of sections, and ordering of sections.
-   Starting from the template is the best way to follow the config topic standard.
+   create file
 
-.. _config topic file template:
+Then select **Science Pipelines documentation > Config topic**.
+
+.. [#template] The config topic file template is maintained in the `lsst/templates repository`_.
+
 .. _lsst/templates repository: https://github.com/lsst/templates/tree/master/file_templates/config_topic
 
 For an example config named ``lsst.example.ExampleConfig``, the rendered template looks like this:

--- a/stack/license-and-copyright.rst
+++ b/stack/license-and-copyright.rst
@@ -21,6 +21,17 @@ You can find the LICENSE file in the `stack_package template <https://github.com
 
 Be careful not to modify the LICENSE file.
 
+.. tip::
+
+   **Create a LICENSE file from Slack.**
+   Open a |dmw-sqrbot| and type:
+
+   .. code-block:: text
+
+      create file
+
+   Then select **General > GPLv3 LICENSE**.
+
 .. _stack-package-copyright:
 
 The COPYRIGHT file
@@ -32,6 +43,17 @@ See :ref:`copyright-file` for information on how to format the :file:`COPYRIGHT`
 All DM developers are expected to participate in maintaining the :file:`COPYRIGHT` file on behalf of your institution.
 Include additions to :file:`COPYRIGHT` files as part of your regular pull requests.
 :download:`/legal/copyright.py` is a script that may help maintain :file:`COPYRIGHT` files.
+
+.. tip::
+
+   **Create a COPYRIGHT file from Slack.**
+   Open a |dmw-sqrbot| and type:
+
+   .. code-block:: text
+
+      create file
+
+   Then select **General > COPYRIGHT file**.
 
 .. _stack-package-preambles:
 
@@ -58,9 +80,20 @@ The license preamble specifically for use in Python files is:
 
 Replace ``{{ cookiecutter.package_name }}`` with the repository's name (``afw``, for example).
 
+.. tip::
+
+   **Create a Python license preamble from Slack.**
+   Open a |dmw-sqrbot| and type:
+
+   .. code-block:: text
+
+      create file
+
+   Then select **Source license preambles > Python**.
+
 See also: :ref:`style-guide-license` in the LSST DM Python Style Guide.
 
-This preamble is available as `a template <https://github.com/lsst/templates/tree/master/file_templates/stack_license_preamble_py>`__.
+This preamble is also available as `a template <https://github.com/lsst/templates/tree/master/file_templates/stack_license_preamble_py>`__.
 
 C++ preamble
 ------------
@@ -72,6 +105,17 @@ The license preamble specifically for use in C++ source and header files is:
 
 Replace ``{{ cookiecutter.package_name }}`` with the repository's name (``afw``, for example).
 
-This preamble is available as `a template <https://github.com/lsst/templates/tree/master/file_templates/stack_license_preamble_cpp>`__.
+.. tip::
+
+   **Create a C++ license preamble from Slack.**
+   Open a |dmw-sqrbot| and type:
+
+   .. code-block:: text
+
+      create file
+
+   Then select **Source license preambles > C++**.
+
+This preamble is also available as `a template <https://github.com/lsst/templates/tree/master/file_templates/stack_license_preamble_cpp>`__.
 
 .. _`GPL-3.0`: https://choosealicense.com/licenses/gpl-3.0/

--- a/stack/script-topic-type.rst
+++ b/stack/script-topic-type.rst
@@ -22,14 +22,17 @@ If your script is written in Python and uses `argparse`, you can automate this r
 Starter template
 ================
 
-The script topic file template is available in the `lsst/templates repository`_.
+Create a new script topic from Slack.\ [#template]_
+Open a |dmw-sqrbot| and type:
 
-.. note::
+.. code-block:: text
 
-   The `script topic template`_ sets technical details like names and labels for sections.
-   Starting from the template is the best way to follow the script topic standard.
+   create file
 
-.. _script topic template:
+Then select **Science Pipelines documentation > Script topic (generic)**.
+
+.. [#template] The script topic file template is available in the `lsst/templates repository`_.
+
 .. _lsst/templates repository: https://github.com/lsst/templates/tree/master/file_templates/script_topic
 
 For an example script named ``exampleScript.sh``, the rendered template looks like this:

--- a/stack/task-topic-type.rst
+++ b/stack/task-topic-type.rst
@@ -12,14 +12,17 @@ This page describes how to write task topic pages for `pipelines.lsst.io <https:
 Starter template
 ================
 
-The task topic file template is available in the `lsst/templates repository`_.
+Create a new task topic from Slack.\ [#template]_
+Open a |dmw-sqrbot| and type:
 
-.. note::
+.. code-block:: text
 
-   The `task topic file template`_ sets technical details like names and labels for sections, and any boilerplate autodocumenting directives.
-   Starting from the template is the best way to follow the task topic standard.
+   create file
 
-.. _task topic file template:
+Then select **Science Pipelines documentation > Task topic**.
+
+.. [#template] The task topic file template is maintained in the `lsst/templates repository`_.
+
 .. _lsst/templates repository: https://github.com/lsst/templates/tree/master/file_templates/task_topic
 
 For an example task named ``lsst.example.ExampleCmdLineTask``, the rendered template looks like this:


### PR DESCRIPTION
Wherever the docs talk about creating a file from a template, or creating a technote, we now provide instructions on how to use @sqrbot-jr on Slack to create that file or project. This is probably the easiest, fastest, and least error-prone way we now have of creating new files and projects.

The docs feature deep links to the `@sqrbot-jr` direct message in the reader's Slack client or web browser (see https://api.slack.com/docs/deep-linking#app_or_bot).

One page that could benefit from this treatment is "Adding a New Package to the Build", but updating that page to mention `@sqrbot-jr create project` would likely require additional edits to that page that are best left to a different PR.