### PR TITLE
Link to package development guide

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -325,6 +325,7 @@ General policies and procedures.
 
 Development.
 
+- `Building a package with the installed Science Pipelines stack <https://pipelines.lsst.io/install/package-development.html>`__
 - :doc:`stack/logging`
 - :doc:`stack/debug`
 

--- a/index.rst
+++ b/index.rst
@@ -326,6 +326,7 @@ General policies and procedures.
 Development.
 
 - `Building a package with the installed Science Pipelines stack <https://pipelines.lsst.io/install/package-development.html>`__
+- `Developing packages on the LSST Science Platform <https://nb.lsst.io/science-pipelines/development-tutorial.html>`__
 - :doc:`stack/logging`
 - :doc:`stack/debug`
 


### PR DESCRIPTION
The guide for building and testing stack packages lives in pipelines.lsst.io, but it's useful to have that link from the DM Stack section of the Developer Guide too.