### PR TITLE
PATs need an additional scope.

### DIFF
--- a/git/git-lfs.rst
+++ b/git/git-lfs.rst
@@ -123,7 +123,7 @@ Once your credentials are cached, you won't need to repeat this process on your 
    **Working with GitHub Two Factor Authentication**
 
    If you have `GitHub's two-factor authentication <https://help.github.com/articles/about-two-factor-authentication/>`_ enabled, use a personal access token instead of a password.
-   You can set up a personal token at https://github.com/settings/tokens with ``read:org`` permissions.
+   You can set up a personal token at https://github.com/settings/tokens with ``public_repo`` and ``read:org`` permissions.
 
 .. _git-lfs-using:
 


### PR DESCRIPTION
2FA access tokens also need the `public_repo` scope.