### PR TITLE
Update git SCL's available

### DIFF
--- a/services/lsst-dev.rst
+++ b/services/lsst-dev.rst
@@ -130,16 +130,15 @@ The following Software Collections are currently available:
 
 ================ ================================================
 Name             Description
-================ ================================================
+================ ==================================================
 ``devtoolset-3`` Updated compiler toolchain providing GCC 4.9.2.
 ``devtoolset-4`` Updated compiler toolchain providing GCC 5.3.1.
 ``devtoolset-6`` Updated compiler toolchain providing GCC 6.3.1.
 ``devtoolset-7`` Updated compiler toolchain providing GCC 7.3.1.
 ``devtoolset-8`` Updated compiler toolchain providing GCC 8.3.1.
 ``devtoolset-9`` Updated compiler toolchain providing GCC 9.1.1.
-``git19``        The `Git`_ version control system version 1.9.4.
-``rh-git29``     The `Git`_ version control system version 2.9.3.
-================ ================================================
+``rh-git218``     The `Git`_ version control system version 2.18.2.
+================ ==================================================
 
 To enable a particular Software Collection use the ``scl`` command. For example:
 
@@ -164,7 +163,7 @@ If you are using `Bash`_ — the default shell on ``lsst-dev`` servers — try p
 .. code-block:: bash
 
    # User-specified space-delimited list of SCLs to enable.
-   desired_scls="rh-git29 devtoolset-8"
+   desired_scls="rh-git218 devtoolset-8"
 
    # Only do anything if /usr/bin/scl is executable.
    if [ -x /usr/bin/scl ]; then


### PR DESCRIPTION
add rh-git218
remove git19 (no longer maintained)
remove rh-git29 (no longer maintained)

We are only removing these from documentation for now (not necessarily removing them from dev servers).