### PR TITLE
Remove outdated devtoolset references

### DIFF
--- a/services/lsst-dev.rst
+++ b/services/lsst-dev.rst
@@ -131,8 +131,6 @@ The following Software Collections are currently available:
 ================ ===========
 Name             Description
 ================ ===========
-``devtoolset-3`` Updated compiler toolchain providing GCC 4.9.2.
-``devtoolset-4`` Updated compiler toolchain providing GCC 5.3.1.
 ``devtoolset-6`` Updated compiler toolchain providing GCC 6.3.1.
 ``devtoolset-7`` Updated compiler toolchain providing GCC 7.3.1.
 ``devtoolset-8`` Updated compiler toolchain providing GCC 8.3.1.


### PR DESCRIPTION
Remove references to devtoolset 3 & 4. No LSST software should be currently built using these, plus these versions are no longer being patched for security issues. This change removes them from documentation only -- removing them from the systems is a later task.