### PR TITLE
remove reference to /datasets/public_html

### DIFF
--- a/services/datasets.rst
+++ b/services/datasets.rst
@@ -33,7 +33,6 @@ Some data resides within ``/datasets`` which does not adhere to this format; the
 The following are currently exempted:
 
 - ``/datasets/all-sky``
-- ``/datasets/public_html``
 
 .. _reference-catalogs:
 


### PR DESCRIPTION
remove reference to /datasets/public_html which has been relocated to /lsstdata/user/staff/web_data