### PR TITLE
DM-25710: Clarify that executable scripts do not need .py suffixes.

### DIFF
--- a/python/style.rst
+++ b/python/style.rst
@@ -619,7 +619,9 @@ Test files must have the form ``test_{description}.py`` for compatibility with P
 The name of a test case should be descriptive without the need for a trailing numeral to distinguish one test case from another.
 
 This rule does not apply to executable script files, for which both no extension and a '.py' extension are acceptable.
-Script files should always be minimal (ideally a single non-import statement), and delegate any actual logic to importable code; this means the impact of having no extension on tools that rely on the file extension should be negligible.
+Script files should always be minimal (ideally a single non-import statement), and delegate any actual logic to importable code.
+This maximizes usability from other Python code (including test code) and makes it much easier to include script interfaces in documentation.
+It also means the impact of having no extension on tools that rely on the file extension should be negligible.
 Legacy scripts that do contain signficant logic should have a '.py' script to support this tooling.
 
 .. TODO consider refactoring tests into their own section

--- a/python/style.rst
+++ b/python/style.rst
@@ -618,6 +618,10 @@ A module containing a single class should be a ``camelCase``-with-leading-lowerc
 Test files must have the form ``test_{description}.py`` for compatibility with Pytest.
 The name of a test case should be descriptive without the need for a trailing numeral to distinguish one test case from another.
 
+This rule does not apply to executable script files, for which both no extension and a '.py' extension are acceptable.
+Script files should always be minimal (ideally a single non-import statement), and delegate any actual logic to importable code; this means the impact of having no extension on tools that rely on the file extension should be negligible.
+Legacy scripts that do contain signficant logic should have a '.py' script to support this tooling.
+
 .. TODO consider refactoring tests into their own section
 
 .. _style-guide-py-file-encoding:


### PR DESCRIPTION
...but they should be minimal, especially if they don't have a .py
suffix.

This implements RFC-698.