### PR TITLE
Kerberos ticket lifetime

### DIFF
--- a/services/lsst-login.rst
+++ b/services/lsst-login.rst
@@ -85,7 +85,7 @@ The Kerberos domain for the ``lsst-login`` servers is ``NCSA.EDU``, so something
 
    **Kerberos Tickets Expire**
 
-   - Your Kerberos ticket on your local machine will expire (generally 25 hours after inititally granted) and need to be renewed, which you can do with ``kinit -R``.
+   - Your Kerberos ticket on your local machine will expire (generally 10 hours after inititally granted) and need to be renewed, which you can do with ``kinit -R``.
    - If your local ticket expires before you renew it, you will have to ``kinit`` (and authenticate with your password) to create a new ticket.
 
 


### PR DESCRIPTION
The default lifetime for a Kerberos ticket is mentioned to be 10 hours, and not 25 hours. https://web.mit.edu/kerberos/krb5-latest/doc/user/tkt_mgmt.html. On my mac OS (Catalina), my tickets expire after 10 hours as well.