### PR TITLE
[DM-29292] Relax formatting rule for one-line docstrings

### DIFF
--- a/python/numpydoc.rst
+++ b/python/numpydoc.rst
@@ -75,7 +75,9 @@ The docstring's :ref:`summary sentence <py-docstring-short-summary>` occurs on t
 
 The terminating ``"""`` should be on its own line except for one-line docstrings.
 If the docstring is a single line, the terminating ``"""`` may be either on the same line or on its own line.
-(Be aware that :pep:`257` requires that it be on the same line and black will enforce this rule.)
+(Be aware that :pep:`257` requires that it be on the same line and `black`_ will enforce this rule.)
+
+.. _black: https://github.com/psf/black
 
 .. code-block:: py
 

--- a/python/numpydoc.rst
+++ b/python/numpydoc.rst
@@ -73,13 +73,20 @@ Docstrings SHOULD begin with ``"""`` and terminate with ``"""`` on its own line
 
 The docstring's :ref:`summary sentence <py-docstring-short-summary>` occurs on the same line as the opening ``"""``.
 
-The terminating ``"""`` should be on its own line, even for 'one-line' docstrings (this is a minor departure from :pep:`257`).
-For example, a one-line docstring:
+The terminating ``"""`` should be on its own line except for one-line docstrings.
+If the docstring is a single line, the terminating ``"""`` may be either on the same line or on its own line.
+(Be aware that :pep:`257` requires that it be on the same line and black will enforce this rule.)
 
 .. code-block:: py
 
    """Sum numbers in an array.
    """
+
+or:
+
+.. code-block:: py
+
+   """Sum numbers in an array."""
 
 (*Note:* one-line docstrings are rarely used for public APIs, see :ref:`py-docstring-sections`.)
 

--- a/python/style.rst
+++ b/python/style.rst
@@ -400,7 +400,9 @@ Wrap lines before binary operators
 ----------------------------------
 
 `PEP 8 suggests <https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator>`_ that lines should be broken before binary operators but allows after.
-For consistency with modern Python conventions and tools such as ``black``, and languages such as SQL, we choose before.
+For consistency with modern Python conventions and tools such as `black`_, and languages such as SQL, we choose before.
+
+.. _black: https://github.com/psf/black
 
 This requires that W503 be disabled in pycodestyle.
 


### PR DESCRIPTION
Allow the closing triple-quote for a one-line docstring in Python
code to be on either the same line as the opening quote or on the
following line.  This permits compliance with PEP 257 and the
formatting enforced by black.  See RFC-762 for discussion.