### PR TITLE
DM-29889: Update documentation for building Science Pipelines documentation with Documenteer in conda

### DIFF
--- a/stack/building-pipelines-lsst-io-locally.rst
+++ b/stack/building-pipelines-lsst-io-locally.rst
@@ -40,12 +40,6 @@ Then set up the `pipelines_lsst_io`_ package with EUPS:
 
    setup -r pipelines_lsst_io
 
-.. warning::
-
-   If you’ve already have packages set up with the :command:`setup` command, you might need to un-setup them with the :command:`unsetup` command before running ``setup -r pipelines_lsst_io``.
-
-   `pipelines_lsst_io`_ acts as a top-level EUPS package, and its table file defines what packages are included in the `pipelines.lsst.io`_ documentation site.
-
 .. _local-pipelines-lsst-io-build-documenteer:
 
 Install Documenteer, the documentation tooling

--- a/stack/building-pipelines-lsst-io-locally.rst
+++ b/stack/building-pipelines-lsst-io-locally.rst
@@ -38,7 +38,7 @@ Then set up the `pipelines_lsst_io`_ package with EUPS:
 
 .. code:: bash
 
-   setup -r pipelines_lsst_io
+   setup -k -r pipelines_lsst_io
 
 .. _local-pipelines-lsst-io-build-documenteer:
 

--- a/stack/building-single-package-docs.rst
+++ b/stack/building-single-package-docs.rst
@@ -27,35 +27,9 @@ This installation should already be set up with a command like :command:`setup l
 This installation needs to be a recent daily or weekly build since you’ll be compiling the `pipe_base`_ repository from its ``master`` branch.
 Working from the tip of the ``master`` branch is the norm for LSST software development.
 
-.. _build-package-docs-documenteer:
-
-Install Documenteer, the documentation tooling
-==============================================
-
-Documenteer_ provides tooling to build `pipelines.lsst.io`_.
-Since it’s a `PyPI-distributed Python package <https://pypi.org/project/documenteer/>`__, you need to install it separately from the EUPS Stack.
-In a base working directory — not inside a repository directory — get the :file:`requirements.txt` file for `pipelines_lsst_io`_ and install it:
-
-.. code-block:: bash
-
-   curl -O https://raw.githubusercontent.com/lsst/pipelines_lsst_io/master/requirements.txt
-   pip install -r requirements.txt
-
-Do this *after* setting up the EUPS Stack with a command like :command:`setup lsst_distrib`.
-
-If it is not already present in your environment, you may also want to install the `graphviz`_ package to enable generation of diagrams:
-
-.. code-block:: bash
-
-   conda install graphviz
-
-.. note::
-
-   On a shared resource, like :doc:`lsst-dev </services/lsst-dev>`, you will need to use a ``--user`` flag with :command:`pip install`.
-
-.. note::
-
-   By using the :file:`requirements.txt` file in the `pipelines_lsst_io`_ repository, you can ensure you’re using the same version of Documenteer_ and its dependencies as in the CI builds of `pipelines.lsst.io`_.
+Finally, the documentation build uses Documenteer_ and related Sphinx_ documentation packages.
+Documenteer_ is already installed if you are using the Rubin Conda environment (part of the usual Science Pipelines installation).
+If this is not the case, see the `Documenteer installation documentation <https://documenteer.lsst.io/pipelines/install.html>`__.
 
 .. _build-package-docs-setup-package:
 
@@ -120,7 +94,8 @@ Further reading
 .. _`Documenteer`: https://documenteer.lsst.io
 .. _`Documenteer’s documentation for more information about the package-docs command`:
 .. _`Documentation for the package-docs command in Documenteer`: https://documenteer.lsst.io/pipelines/package-docs-cli.html
+.. _`Documenteer installation documentation`: https://documenteer.lsst.io/pipelines/install.html
 .. _`pipelines.lsst.io`: https://pipelines.lsst.io
 .. _`pipelines_lsst_io`: https://github.com/lsst/pipelines_lsst_io
 .. _`pipe_base`: https://github.com/lsst/pipe_base
-.. _`graphviz`: https://graphviz.org
+.. _`Sphinx`: https://www.sphinx-doc.org/en/master/


### PR DESCRIPTION
This PR updates the Pipelines documentation build instructions given that documenteer is now included in the Science Pipeline's conda environment:

- https://developer.lsst.io/v/DM-29889/stack/building-single-package-docs.html
- https://developer.lsst.io/v/DM-29889/stack/building-pipelines-lsst-io-locally.html

In https://github.com/lsst/templates/pull/118 we're updating the template, and that will automatically be reflected in an updated section on the doc/conf.py file in the "Layout of the doc/ directory page" https://developer.lsst.io/stack/layout-of-doc-directory.html#the-doc-conf-py-file (the code sample pulls data from the templates repo).