### PR TITLE
Add link to from pybind11 to python property section

### DIFF
--- a/pybind11/style.rst
+++ b/pybind11/style.rst
@@ -555,9 +555,7 @@ The same rule applies for in-place operators:  ``__itruediv__`` and ``__ifloordi
 All rules from the Python style guide regarding properties SHALL also apply to C++ wrappers
 -------------------------------------------------------------------------------------------
 
-.. note::
-
-    These rules are currently under development.
+See :ref:`style-guide-py-properties` in the python guide.
 
 .. _style-guide-pybind11-module-docstrings:
 


### PR DESCRIPTION
I noticed that the pybind11 section about python properties was still a TBD, but RFC-279 was implemented years ago. I think all we need here is a link to the python section, no?