### PR TITLE
Change See Also Section to title case

### DIFF
--- a/python/numpydoc.rst
+++ b/python/numpydoc.rst
@@ -324,6 +324,12 @@ These are the sections and their relative order:
 9. :ref:`References <py-docstring-references>` (optional)
 10. :ref:`Examples <py-docstring-examples>` (optional)
 
+.. important::
+
+   These sections — including names, capitalizations, and relative order — are highly prescribed by the Numpydoc standard and the tooling that works in that ecosystem including documentation builders (Sphinx) and linters (pydocstyle).
+   You cannot add custom sections.
+   Also note that the sections are title cased (e.g. "See Also"), as opposed to the sentence casing recommended otherwise in our :ref:`user-doc-style-guide`.
+
 For summaries of how these docstring sections are composed in specific contexts, see:
 
 - :ref:`py-docstring-module-structure`


### PR DESCRIPTION
The title case is required by pydoclint, so it makes sense to use that standard for community compatibility, despite disagreeing with our general usage of sentence case in user documentation.