### PR TITLE
Clarify that the short summary should always describe changes in PR

### DIFF
--- a/work/flow.rst
+++ b/work/flow.rst
@@ -366,7 +366,8 @@ The pull request's title should be prefixed with the Jira ticket handle, followe
    DM-NNNN: {{Short summary}}
 
 This format helps you and other developers find the right pull request when browsing repositories on GitHub.
-The short summary does not need to match the Jira issue's title, but should describe the code changes.
+The short summary should describe the code changes.
+It can often be the Jira title if that is relevant to the changes.
 
 The pull request's description shouldn't be exhaustive; only include information that will help frame the review.
 Background information should already be in the JIRA ticket description, commit messages, and code documentation.


### PR DESCRIPTION
Remove the confusion that Jira title can be used even if this is a supplementary PR that is only tangentially related to the main purpose of the Jira ticket.