### PR TITLE
DM-36409: Update stack-os-matrix docs to reflect current system

### DIFF
--- a/stack/jenkins-stack-os-matrix.rst
+++ b/stack/jenkins-stack-os-matrix.rst
@@ -34,6 +34,10 @@ Running a stack-os-matrix job
      - ``ci_hsc`` exercises most of the Data Release Production pipelines, including single-frame processing and coaddition, on HSC engineering data. This package is also run as part of the nightly build.
      - ``ci_imsim`` runs the same on simulated Rubin Observatory data. Like ``ci_hsc``, it's run nightly in addition to as part of ``stack-os-matrix``.
 
+   - **Set the conda environment** to run on.
+     The default is the latest ``rubin-env`` package.
+     You should only need to change this when testing a new environment, or to temporarily work around bugs introduced in the latest version.
+
 4. Click the **Run** button in the dialog to start the build.
 
 Monitoring the run status

--- a/stack/jenkins-stack-os-matrix.rst
+++ b/stack/jenkins-stack-os-matrix.rst
@@ -20,8 +20,10 @@ Running a stack-os-matrix job
 
      For example, if you enter ``tickets/DM-2 tickets/DM-1``, the build system will attempt to check out the ``tickets/DM-2`` branch in Stack packages.
      If a package does not have a ``tickets/DM-2`` branch, it will attempt to check out the ``tickets/DM-1`` branch.
+
      If a package has neither branch, it falls back to checking out the ``main`` branch or the branch configured in ``repos.yaml`` in the case of forked third-party packages.
      Because of those third-party packages, you *never* want to specify ``main`` explicitly in this field.
+     To check that a ``main``-only build passes, leave the refs box entirely blank.
 
    - **Set the list of EUPS packages** to build.
      Use the default (``lsst_distrib lsst_ci``) to build and test your changes with a full Stack.

--- a/stack/jenkins-stack-os-matrix.rst
+++ b/stack/jenkins-stack-os-matrix.rst
@@ -28,7 +28,11 @@ Running a stack-os-matrix job
      To improve build times you can instead specify the name of the package you are actively developing.
      Before you merge a ticket branch to ``main``, **you must** run a stack-os-matrix Job with at least the default packages so that the full Stack is built and tested with your changes.
 
+     There are also several packages that can be appended to the default to do more thorough testing at the cost of much longer build times:
 
+     - ``ci_cpp`` exercises the Calibration Products Pipeline in ways that are too computationally expensive for unit tests in ``cp_pipe``.
+     - ``ci_hsc`` exercises most of the Data Release Production pipelines, including single-frame processing and coaddition, on HSC engineering data. This package is also run as part of the nightly build.
+     - ``ci_imsim`` runs the same on simulated Rubin Observatory data. Like ``ci_hsc``, it's run nightly in addition to as part of ``stack-os-matrix``.
 
 4. Click the **Run** button in the dialog to start the build.
 

--- a/stack/jenkins-stack-os-matrix.rst
+++ b/stack/jenkins-stack-os-matrix.rst
@@ -24,14 +24,11 @@ Running a stack-os-matrix job
      Because of those third-party packages, you *never* want to specify ``main`` explicitly in this field.
 
    - **Set the list of EUPS packages** to build.
-     Use the default (``lsst_distrib``) to build and test your changes with a full Stack.
-     To improve build times you can instead specify the name of the package you are actively developing and check the **Skip Demo** box.
+     Use the default (``lsst_distrib lsst_ci``) to build and test your changes with a full Stack.
+     To improve build times you can instead specify the name of the package you are actively developing.
+     Before you merge a ticket branch to ``main``, **you must** run a stack-os-matrix Job with at least the default packages so that the full Stack is built and tested with your changes.
 
-   - **Check the Skip Demo** option only if you are testing your package alone (in conjunction with specifying your package in the prior text box).
 
-     Before you merge a ticket branch to ``main``, **you must** run a stack-os-matrix Job without **Skip Demo** enabled so that the full Stack is built and tested with your changes.
-
-     When the ``demo`` is run, the `lsst_ci`_ top-level package is automatically added to the build and the `lsst_dm_stack_demo`_ is run to test a simple :command:`processCcd.py`\ -based pipeline.
 
 4. Click the **Run** button in the dialog to start the build.
 


### PR DESCRIPTION
This PR updates the description of the `stack-os-matrix` job to reflect current practice, and adds some notes about gotchas that I've run into myself.

The built documentation can be found at https://developer.lsst.io/v/DM-36409/stack/jenkins-stack-os-matrix.html.