### PR TITLE
Pin Sphinx<6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 documenteer
 sphinx-prompt
 sphinx_rtd_theme
+sphinx<6.0.0


### PR DESCRIPTION
Pin Sphinx<6; Sphinx 6 dropped packaging jquery and that's hampering the on-site search functionality. I think that sphinx_rtd_theme show take over including jquery, but I'll have to verify.