### PR TITLE
Add notes on dev env to single package docs build

### DIFF
--- a/stack/building-pipelines-lsst-io-locally.rst
+++ b/stack/building-pipelines-lsst-io-locally.rst
@@ -20,6 +20,10 @@ Before starting, you’ll need a working ``lsst_distrib`` installation.
 
 This installation needs to be a recent daily or weekly build so that any in-development packages will compile with the Stack. Working from the tip of the ``main`` branch is the norm for LSST software development.
 
+The documentation build uses Documenteer_ and related Sphinx_ documentation packages, which are already installed if you are using the Rubin Conda developer environment.
+You can check if ``rubin-env-developer`` is installed by running ``mamba list rubin-env``.
+If not, you can install the developer environment with: ``mamba install rubin-env-developer``.
+
 .. _local-pipelines-lsst-io-build-clone:
 
 Clone and set up the pipelines\_lsst\_io repository
@@ -116,3 +120,4 @@ Further reading
 .. _`pipelines_lsst_io`: https://github.com/lsst/pipelines_lsst_io
 .. _`pipe_base`: https://github.com/lsst/pipe_base
 .. _`graphviz`: https://graphviz.org
+.. _`Sphinx`: https://www.sphinx-doc.org/en/master/

--- a/stack/building-single-package-docs.rst
+++ b/stack/building-single-package-docs.rst
@@ -27,9 +27,9 @@ This installation should already be set up with a command like :command:`setup l
 This installation needs to be a recent daily or weekly build since you’ll be compiling the `pipe_base`_ repository from its ``main`` branch.
 Working from the tip of the ``main`` branch is the norm for LSST software development.
 
-Finally, the documentation build uses Documenteer_ and related Sphinx_ documentation packages.
-Documenteer_ is already installed if you are using the Rubin Conda environment (part of the usual Science Pipelines installation).
-If this is not the case, see the `Documenteer installation documentation <https://documenteer.lsst.io/pipelines/install.html>`__.
+The documentation build uses Documenteer_ and related Sphinx_ documentation packages, which are already installed if you are using the Rubin Conda developer environment.
+You can check if ``rubin-env-developer`` is installed by running ``mamba list rubin-env``.
+If not, you can install the developer environment with: ``mamba install rubin-env-developer``.
 
 .. _build-package-docs-setup-package:
 


### PR DESCRIPTION
The dev guide did not say anything about `rubin-env-developer`, which is where the `package-docs` command now lives. I tried to reword this page to reflect this; not sure if the `mamba` command should be pulled out into a separate bullet?