### PR TITLE
Clarification for user branches

### DIFF
--- a/work/flow.rst
+++ b/work/flow.rst
@@ -274,7 +274,7 @@ These branches are named
 
 .. code-block:: text
 
-   u/{{username}}/{{topic}}
+   u/{{github-username}}/{{topic}}
 
 User branches can be pushed to GitHub to enable collaboration and communication.
 Before offering unsolicited code review on your colleagues' user branches, remember that the work is intended to be an early prototype.


### PR DESCRIPTION
Added clarification that it should be your github username on user branches, not usdf or other LSST/Rubin usernames.

If this should be left as is, let me know and I'll close the PR.