### PR TITLE
DM-39199: Add a note about FITS libraries from Python

### DIFF
--- a/python/astropy.rst
+++ b/python/astropy.rst
@@ -13,10 +13,6 @@ Integration of Astropy core into the LSST software stack is an ongoing process t
 This document is not discussing Astropy affiliated packages, use of which must go through the standard :doc:`RFC </communications/rfc>` process.
 Not all Astropy core packages can be used by default.
 
-The following packages should be used from Astropy in preference to other Python packages:
-
-* :mod:`astropy.io.fits` instead of ``pyfits`` (use of ``pyfits`` is now deprecated).
-
 The following packages can be used internally in packages if they do not leak into public APIs:
 
 * :mod:`astropy.coordinates`
@@ -27,6 +23,16 @@ The following packages can be used internally in packages if they do not leak in
 * :mod:`astropy.constants`
 * :mod:`astropy.cosmology`
 * :mod:`astropy.visualization`
+
+For reading and writing files in FITS format, both :mod:`astropy.io.fits` and `fitsio`_ are allowed.
+These libraries differ in the features available and in performance (with the latter usually surpassing the former).
+Developers must evaluate which works best for their use case and choose one accordingly.
+
+.. _fitsio: https://github.com/esheldon/fitsio
+
+.. warning::
+
+    ``lsst.afw.fits`` must not be used in any new Python code, as it is not considered memory safe.
 
 The interaction of Astropy with LSST C++ classes providing related functionality should be carefully monitored.
 If the code is already using ``afw`` it is strongly preferred that ``afw`` equivalents be used until such time as specific ``afw`` interfaces are deprecated.


### PR DESCRIPTION
as requested by the DM-CCB on RFC-921.