### PR TITLE
Specify that __all__ should be a tuple

### DIFF
--- a/pybind11/how-to.rst
+++ b/pybind11/how-to.rst
@@ -960,7 +960,7 @@ We'll use the ``continueClass`` decorator to reopen the class and add a new meth
 
     from ._tmpl import ExampleTwo
 
-    __all__ = []  # import for side effects
+    __all__ = ()  # import for side effects
 
 
     @continueClass
@@ -999,7 +999,7 @@ As with ``ExampleTwo``, add this to a pure-Python ``_ExampleThree.py``:
 
     from ._tmpl import ExampleThreeI, ExampleThreeD
 
-    __all__ = ["ExampleThree"]
+    __all__ = ("ExampleThree", )
 
 
     class ExampleThree(metaclass=TemplateMeta):

--- a/python/style.rst
+++ b/python/style.rst
@@ -643,7 +643,7 @@ Within a module, follow the order:
 #. Shebang line, ``#! /usr/bin/env python`` (only for executable scripts)
 #. Module-level comments (such as the `license statement <https://github.com/lsst/templates/tree/main/file_templates/stack_license_py>`__)
 #. Module-level docstring
-#. ``__all__ = [...]`` statement, if present
+#. ``__all__ = (...)`` statement, if present
 #. Imports
 #. Private module variables (names start with underscore)
 #. Private module functions and classes (names start with underscore)

--- a/stack/module-homepage-topic-type.rst
+++ b/stack/module-homepage-topic-type.rst
@@ -232,7 +232,7 @@ You may need to exclude APIs from automodapi_ for two reasons:
 2. The API includes a broken docstring, and you need to remove that API temporarily.
 
 The main tool for removing non-public APIs from the published documentation is ``__all__``.
-Each module should provide an ``__all__`` that explicitly lists the module’s public APIs.
+Each module should provide an ``__all__`` tuple that explicitly lists the module’s public APIs.
 `automodapi`_ respects ``__all__``.
 
 .. _module-homepage-automodapi-skip:


### PR DESCRIPTION
We've had some conversation about this on slack in the past, and settled on tuple, but never specified it in the dev guide.