### PR TITLE
DM-45482: Replace reference to setup.sh with envconfig and add how to change rubin-env

### DIFF
--- a/stack/conda.rst
+++ b/stack/conda.rst
@@ -39,6 +39,7 @@ To see all available ``rubin-env`` in your terminal run the following:
    conda search -c nodefaults  -c conda-forge rubin-env
 
 This command will print out only production ready ``rubin-env`` versions.
+It's best to start from a fresh shell when running bin/deploy to avoid confusion.
 To change the ``rubin-env``:
 
 .. code-block:: bash
@@ -54,14 +55,15 @@ To change the ``rubin-env``:
 Using developer rubin-env environments
 --------------------------------------
 
-You might also want to switch to rubin-env that are still under development.
-To do so, add the label conda-forge/label/rubin-env_dev as follows:
+You might also want to switch to ``rubin-env`` versions that are still under development.
+To do so, add the label ``conda-forge/label/rubin-env_dev`` as follows:
 
 .. code-block:: bash
 
    conda search -c nodefaults  -c conda-forge rubin-env -c conda-forge/label/rubin-env_dev
 
-This command will print out all available ``rubin-env`` including ones that are still under development (rubin-env_dev).
+This command will print out all available ``rubin-env`` including ones that are still under development (``rubin-env_dev``).
+Again, start from a fresh shell for each bin/deploy to avoid confusion.
 To change the ``rubin-env``:
 
 .. code-block:: bash
@@ -79,7 +81,7 @@ Dependency versions
 -------------------
 
 The package specifications that define ``rubin-env`` typically specify minimum versions.
-These provide guarantees so that Science Pipelines developers can rely on features of the packages in their code.  
+These provide guarantees so that Science Pipelines developers can rely on features of the packages in their code.
 Features newer than the minimum versions for the environment, or for packages that are not directly listed dependencies, should not be relied on.
 
 The use of minimum and not exact versions is intentional so that users can add packages on top of ``rubin-env`` with a minimum of conflicts.

--- a/stack/conda.rst
+++ b/stack/conda.rst
@@ -24,6 +24,48 @@ Note that each of these other environments is maintained separately; see below.
 Requests for additions to ``rubin-env`` should be made via RFC.
 The DM-CCB must approve such requests.
 
+.. _rubin-env-switching-versions:
+
+Switching rubin-env versions
+----------------------------
+
+There might be an instance where you might need to change the current version of rubin-env.
+You can view the current available env `here <https://anaconda.org/conda-forge/rubin-env/files>`__
+To see all available ``rubin-env`` in your terminal run the following:
+
+.. code-block:: bash
+
+   conda search -c nodefaults  -c conda-forge rubin-env
+
+This command will print out only production ready ``rubin-env``.
+To change the ``rubin-env``:
+
+.. code-block:: bash
+
+   git clone https://github.com/lsst/lsstsw
+   cd lsstsw
+   LSST_CONDA_CHANNELS="nodefaults conda-forge"
+   ./bin/deploy -v 8.0.0 # or any other rubin env
+   source bin/envconfig -n lsst-scipipe-8.0.0
+   rebuild lsst_apps # This could be any branch or product you want to use
+
+You might also want to switch to rubin-env that are still under development. To do so, add the label conda-forge/label/rubin-env_dev as follows:
+
+.. code-block:: bash
+
+   conda search -c nodefaults  -c conda-forge rubin-env -c conda-forge/label/rubin-env_dev
+
+This command will print out all available ``rubin-env`` including ones that are still under development (rubin-env_dev).
+To change the ``rubin-env``:
+
+.. code-block:: bash
+
+   git clone https://github.com/lsst/lsstsw
+   cd lsstsw
+   LSST_CONDA_CHANNELS="nodefaults conda-forge/label/rubin-env_dev conda-forge" # adding conda-forge/label/rubin-env_dev allows to install rubin-env_dev
+   ./bin/deploy -v 9.0.0dev # or any other rubin env
+   source bin/envconfig -n lsst-scipipe-9.0.0dev
+   rebuild lsst_apps # This could be any branch or product you want to use
 .. _rubin-env-dependency-versioning:
 
 Dependency versions

--- a/stack/conda.rst
+++ b/stack/conda.rst
@@ -29,27 +29,33 @@ The DM-CCB must approve such requests.
 Switching rubin-env versions
 ----------------------------
 
-There might be an instance where you might need to change the current version of rubin-env.
-You can view the current available env `here <https://anaconda.org/conda-forge/rubin-env/files>`__
+Occasionally, you may need to switch the version of ``rubin-env`` you are using.
+Below, you'll find instructions on how to view available versions and switch between them.
+You can view the current available env versions `on conda-forge <https://anaconda.org/conda-forge/rubin-env/files>`__.
 To see all available ``rubin-env`` in your terminal run the following:
 
 .. code-block:: bash
 
    conda search -c nodefaults  -c conda-forge rubin-env
 
-This command will print out only production ready ``rubin-env``.
+This command will print out only production ready ``rubin-env`` versions.
 To change the ``rubin-env``:
 
 .. code-block:: bash
 
-   git clone https://github.com/lsst/lsstsw
-   cd lsstsw
-   LSST_CONDA_CHANNELS="nodefaults conda-forge"
+   conda deactivate # make sure you do not run this inside an existing conda environment
    ./bin/deploy -v 8.0.0 # or any other rubin env
    source bin/envconfig -n lsst-scipipe-8.0.0
    rebuild lsst_apps # This could be any branch or product you want to use
 
-You might also want to switch to rubin-env that are still under development. To do so, add the label conda-forge/label/rubin-env_dev as follows:
+
+.. _rubin-env-dev-switching-versions:
+
+Using developer rubin-env environments
+--------------------------------------
+
+You might also want to switch to rubin-env that are still under development.
+To do so, add the label conda-forge/label/rubin-env_dev as follows:
 
 .. code-block:: bash
 
@@ -60,12 +66,13 @@ To change the ``rubin-env``:
 
 .. code-block:: bash
 
-   git clone https://github.com/lsst/lsstsw
-   cd lsstsw
-   LSST_CONDA_CHANNELS="nodefaults conda-forge/label/rubin-env_dev conda-forge" # adding conda-forge/label/rubin-env_dev allows to install rubin-env_dev
+   conda deactivate # make sure you do not run this inside an existing conda environment
+   # adding conda-forge/label/rubin-env_dev allows to install rubin-env_dev
+   LSST_CONDA_CHANNELS="nodefaults conda-forge/label/rubin-env_dev conda-forge"
    ./bin/deploy -v 9.0.0dev # or any other rubin env
    source bin/envconfig -n lsst-scipipe-9.0.0dev
    rebuild lsst_apps # This could be any branch or product you want to use
+
 .. _rubin-env-dependency-versioning:
 
 Dependency versions

--- a/stack/lsstsw.rst
+++ b/stack/lsstsw.rst
@@ -42,7 +42,7 @@ example::
 
     export LSSTSW=<where you've set it up>
     export EUPS_PATH=$LSSTSW/stack
-    . $LSSTSW/bin/setup.sh
+    . $LSSTSW/bin/envconfig
 
 .. DO NOT use double quotes in examples -- it activates syntax highlighting
 
@@ -50,7 +50,7 @@ example::
 
     setenv LSSTSW <where you've set it up>
     setenv EUPS_PATH $LSSTSW/stack
-    source $LSSTSW/bin/setup.csh
+    source $LSSTSW/bin/envconfig.csh
 
 .. note::
 


### PR DESCRIPTION
Replace reference to bin/setup.sh with bin/envconfig.
Adds documentation on how to change rubin-env version with a different one.