### PR TITLE
DM-48755: Repoint sqrbot-jr to squarebot in rubin-obs Slack

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -140,8 +140,8 @@ else:
 
 # Common substitutions and link targets available in every document
 rst_epilog = """
-.. |sqrbot| replace:: `@sqrbot-jr <https://slack.com/app_redirect?app=AF2U6ADV3&team=T06D204F2>`__
-.. |dmw-sqrbot| replace:: `direct message with @sqrbot-jr <https://slack.com/app_redirect?app=AF2U6ADV3&team=T06D204F2>`__
+.. |squarebot| replace:: `@squarebot <https://slack.com/app_redirect?app=A07PWG9UG9M&team=T02SVMGU4>`__
+.. |dmw-squarebot| replace:: `direct message with @squarebot <https://slack.com/app_redirect?app=A07PWG9UG9M&team=T02SVMGU4>`__
 """
 
 

--- a/legal/copyright-overview.rst
+++ b/legal/copyright-overview.rst
@@ -154,7 +154,7 @@ The :file:`COPYRIGHT` file does not contain any other content.
 .. tip::
 
    **Create a COPYRIGHT file from Slack.**
-   Open a |dmw-sqrbot| and type:
+   Open a |dmw-squarebot| and type:
 
    .. code-block:: text
 

--- a/project-docs/change-controlled-docs.rst
+++ b/project-docs/change-controlled-docs.rst
@@ -100,7 +100,7 @@ Creating a new LaTeX (lsstdoc) change-controlled document
 **Before creating a new change-controlled document, reserve its handle on DocuShare.**
 Contact the CCB (`#dm-ccb <slack://channel?team=T06D204F2&id=C2JPBA2SU>`_) for assistance.
 
-In Slack, open a |dmw-sqrbot| and type:
+In Slack, open a |dmw-squarebot| and type:
 
 .. code-block:: text
 

--- a/project-docs/technotes.rst
+++ b/project-docs/technotes.rst
@@ -79,7 +79,7 @@ Create a technote
 =================
 
 Creating a new technote is easy and takes just a moment.
-In Slack, open a |dmw-sqrbot| and type:
+In Slack, open a |dmw-squarebot| and type:
 
 .. code-block:: text
 

--- a/stack/adding-a-new-package.rst
+++ b/stack/adding-a-new-package.rst
@@ -7,7 +7,7 @@ Adding a New Package to the Build
 Creating a new package
 ======================
 
-To create a new LSST package, send a "create project" message to ``@sqrbot-jr`` on the LSST Slack and select "LSST EUPS package" as the project type.
+To create a new LSST package, send a "create project" message to ``@squarebot`` on the LSST Slack and select "LSST EUPS package" as the project type.
 Follow the prompts to select the GitHub organization (choose ``lsst`` for the `LSST organization on GitHub`_ for packages that you plan to add to the full distribution via RFC, as described below) and the specific flavor of package (e.g. ``Pipelines Python`` for a typical python package that depends on `pipe_base`_)  to get an appropriate directory structure set up.
 The bot uses the templates in the `lsst/templates`_ repository to define the package layout.
 
@@ -99,8 +99,8 @@ Configuring GitHub Repositories
 
 .. Note::
 
-  If you created your package via ``@sqrbot-jr`` on the LSST slack, the GitHub repo should be configured correctly.
-  These instructions are for the rare cases that cannot be handled by ``@sqrbot-jr``.
+  If you created your package via ``@squarebot`` on the LSST slack, the GitHub repo should be configured correctly.
+  These instructions are for the rare cases that cannot be handled by ``@squarebot``.
 
 All LSST DM repositories on GitHub must be configured by a repository administrator to protect the ``main`` branch and to ensure that the merge button for pull requests can not be pushed without the branch being up to date with ``main``.
 There are a number of settings required to ensure this and they are described below with URLs referring to the ``afw`` package.
@@ -145,7 +145,7 @@ Handling Git LFS-backed repos
 =============================
 
 New :doc:`Git LFS-backed </git/git-lfs>` repos (or existing repos being converted to LFS) require additional configuration.
-``@sqrbot-jr`` cannot yet create an empty LFS-ready repo.
+``@squarebot`` cannot yet create an empty LFS-ready repo.
 
 - The `repos.yaml`_ entry must declare that the repository is LFS backed:
 

--- a/stack/argparse-script-topic-type.rst
+++ b/stack/argparse-script-topic-type.rst
@@ -19,7 +19,7 @@ Starter template
 ================
 
 Create a new argparse-based script topic from Slack.\ [#template]_
-Open a |dmw-sqrbot| and type:
+Open a |dmw-squarebot| and type:
 
 .. code-block:: text
 

--- a/stack/config-topic-type.rst
+++ b/stack/config-topic-type.rst
@@ -15,7 +15,7 @@ Starter template
 ================
 
 Create a new config topic from Slack.\ [#template]_
-Open a |dmw-sqrbot| and type:
+Open a |dmw-squarebot| and type:
 
 .. code-block:: text
 

--- a/stack/license-and-copyright.rst
+++ b/stack/license-and-copyright.rst
@@ -24,7 +24,7 @@ Be careful not to modify the LICENSE file.
 .. tip::
 
    **Create a LICENSE file from Slack.**
-   Open a |dmw-sqrbot| and type:
+   Open a |dmw-squarebot| and type:
 
    .. code-block:: text
 
@@ -47,7 +47,7 @@ Include additions to :file:`COPYRIGHT` files as part of your regular pull reques
 .. tip::
 
    **Create a COPYRIGHT file from Slack.**
-   Open a |dmw-sqrbot| and type:
+   Open a |dmw-squarebot| and type:
 
    .. code-block:: text
 
@@ -83,7 +83,7 @@ Replace ``{{ cookiecutter.package_name }}`` with the repository's name (``afw``,
 .. tip::
 
    **Create a Python license preamble from Slack.**
-   Open a |dmw-sqrbot| and type:
+   Open a |dmw-squarebot| and type:
 
    .. code-block:: text
 
@@ -108,7 +108,7 @@ Replace ``{{ cookiecutter.package_name }}`` with the repository's name (``afw``,
 .. tip::
 
    **Create a C++ license preamble from Slack.**
-   Open a |dmw-sqrbot| and type:
+   Open a |dmw-squarebot| and type:
 
    .. code-block:: text
 

--- a/stack/script-topic-type.rst
+++ b/stack/script-topic-type.rst
@@ -23,7 +23,7 @@ Starter template
 ================
 
 Create a new script topic from Slack.\ [#template]_
-Open a |dmw-sqrbot| and type:
+Open a |dmw-squarebot| and type:
 
 .. code-block:: text
 

--- a/stack/task-topic-type.rst
+++ b/stack/task-topic-type.rst
@@ -13,7 +13,7 @@ Starter template
 ================
 
 Create a new task topic from Slack.\ [#template]_
-Open a |dmw-sqrbot| and type:
+Open a |dmw-squarebot| and type:
 
 .. code-block:: text
 


### PR DESCRIPTION
We've disabled sqrbot-jr in the now Discovery Alliance Slack, so all users must adopt Squarebot in the rubin-obs Slack workspace. This change updates the deep link URLs and refreshes references to sqrbot-jr to reflect Squarebot.